### PR TITLE
Fix Vercel build by removing Next.js detection

### DIFF
--- a/src/api/projects.js
+++ b/src/api/projects.js
@@ -1,3 +1,4 @@
+// Moved from pages/api to src/api to avoid Next.js detection on Vercel
 export default function handler(req, res) {
   const projets = [
     {

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "framework": "vite"
+}


### PR DESCRIPTION
## Summary
- move `pages/api` folder to `src/api`
- add Vercel configuration for Vite
- annotate moved API file

## Testing
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6869fa3394d08331961c54abd489cb3b