### PR TITLE
Use env for EmailJS credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Example environment variables for the portfolio project
+
+# EmailJS configuration
+VITE_EMAILJS_PUBLIC_KEY=your_emailjs_public_key
+VITE_EMAILJS_SERVICE_ID=your_emailjs_service_id
+VITE_EMAILJS_TEMPLATE_ID=your_emailjs_template_id
+
+# Supabase configuration
+VITE_SUPABASE_URL=your_supabase_url
+VITE_SUPABASE_ANON_KEY=your_supabase_anon_key

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # Porfolio
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and populate the values for EmailJS and Supabase:
+
+```
+cp .env.example .env
+```
+
+Required variables:
+
+- `VITE_EMAILJS_PUBLIC_KEY`
+- `VITE_EMAILJS_SERVICE_ID`
+- `VITE_EMAILJS_TEMPLATE_ID`
+- `VITE_SUPABASE_URL`
+- `VITE_SUPABASE_ANON_KEY`

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -4,6 +4,10 @@ import { useInView } from 'react-intersection-observer';
 import { Send, CheckCircle } from 'lucide-react';
 import emailjs from '@emailjs/browser';
 
+const EMAILJS_PUBLIC_KEY = import.meta.env.VITE_EMAILJS_PUBLIC_KEY!;
+const EMAILJS_SERVICE_ID = import.meta.env.VITE_EMAILJS_SERVICE_ID!;
+const EMAILJS_TEMPLATE_ID = import.meta.env.VITE_EMAILJS_TEMPLATE_ID!;
+
 const Contact: React.FC = () => {
   const formRef = useRef<HTMLFormElement>(null);
   const [loading, setLoading] = useState(false);
@@ -16,7 +20,7 @@ const Contact: React.FC = () => {
   });
 
   useEffect(() => {
-    emailjs.init("w2jrqSt-GwSCQR7zM");
+    emailjs.init(EMAILJS_PUBLIC_KEY);
   }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -29,8 +33,8 @@ const Contact: React.FC = () => {
       setError('');
       
       const result = await emailjs.sendForm(
-        'default_service', 
-        'template_2isjmxk',
+        EMAILJS_SERVICE_ID,
+        EMAILJS_TEMPLATE_ID,
         formRef.current
       );
       


### PR DESCRIPTION
## Summary
- load EmailJS credentials in `Contact` component from environment variables
- add `.env.example` with required variables
- document environment variables in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_686a379f7afc833196ac0ef596e8c6fe