### PR TITLE
Remove duplicate "My Projects" button

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -107,14 +107,6 @@ const Hero: React.FC = () => {
               {t('about.downloadCv')}
             </a>
           </motion.div>
-          <motion.div variants={itemVariants}>
-            <a
-              href="#projects"
-              className="px-8 py-4 border border-white text-white hover:bg-white hover:text-black transition-colors duration-300 inline-block"
-            >
-              {t("hero.cta")}
-            </a>
-          </motion.div>
         </motion.div>
 
         <motion.div


### PR DESCRIPTION
## Summary
- clean up Hero section
- drop "My Projects" button since navigation already links to projects

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686a918047ec8331afd28682d9ee1cd4