### PR TITLE
Add dark mode toggle

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,6 +3,7 @@ import { motion } from "framer-motion";
 import { Menu, X } from "lucide-react";
 import LanguageSelector from "./LanguageSelector";
 import SocialLinks from "./SocialLinks";
+import ThemeToggle from "./ThemeToggle";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 
@@ -59,9 +60,10 @@ const Header: React.FC = () => {
           </div>
         </div>
 
-        {/* Sélecteur de langue */}
-        <div className="hidden md:block ml-4">
+        {/* Language selector and theme toggle */}
+        <div className="hidden md:flex items-center ml-4 space-x-4">
           <LanguageSelector />
+          <ThemeToggle />
         </div>
 
         {/* Menu desktop */}
@@ -115,6 +117,7 @@ const Header: React.FC = () => {
             </Link>
           ))}
           <SocialLinks />
+          <ThemeToggle />
         </div>
       </motion.div>
     </header>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,32 @@
+import React, { useEffect, useState } from 'react';
+
+const ThemeToggle: React.FC = () => {
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme');
+    const prefersDark =
+      stored === 'dark' || (!stored && window.matchMedia('(prefers-color-scheme: dark)').matches);
+    setIsDark(prefersDark);
+  }, []);
+
+  useEffect(() => {
+    if (isDark) {
+      document.documentElement.classList.add('dark');
+      localStorage.setItem('theme', 'dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+      localStorage.setItem('theme', 'light');
+    }
+  }, [isDark]);
+
+  return (
+    <label className="theme-toggle">
+      <input type="checkbox" checked={isDark} onChange={() => setIsDark(!isDark)} />
+      <span className="slider" />
+    </label>
+  );
+};
+
+export default ThemeToggle;
+

--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,10 @@
 @tailwind utilities;
 
 :root {
+  color-scheme: light;
+}
+
+.dark {
   color-scheme: dark;
 }
 
@@ -11,7 +15,7 @@ html {
 }
 
 body {
-  @apply bg-darker text-white font-sans m-0 p-0 overflow-x-hidden;
+  @apply bg-light text-black dark:bg-darker dark:text-white font-sans m-0 p-0 overflow-x-hidden;
   opacity: 1 !important;
 }
 
@@ -138,4 +142,36 @@ body {
   html {
     scroll-behavior: auto;
   }
+}
+
+/* Theme toggle slider */
+.theme-toggle {
+  @apply relative inline-block w-12 h-6 align-middle select-none;
+}
+
+.theme-toggle input {
+  @apply hidden;
+}
+
+.theme-toggle .slider {
+  @apply absolute inset-0 cursor-pointer bg-gray-300 dark:bg-gray-600 rounded-full transition-colors;
+}
+
+.theme-toggle .slider:before {
+  content: '\2605'; /* star */
+  @apply absolute left-1 top-1 text-yellow-400 text-sm transition-transform;
+}
+
+.theme-toggle .slider:after {
+  content: '\2601'; /* cloud */
+  @apply absolute right-1 top-1 text-gray-600 text-sm opacity-0 transition-opacity;
+}
+
+.theme-toggle input:checked + .slider:before {
+  transform: translateX(18px);
+  @apply text-white;
+}
+
+.theme-toggle input:checked + .slider:after {
+  @apply opacity-100;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
- enable class-based dark mode in Tailwind
- set light scheme as default and add dark body styles
- add slider-based ThemeToggle component
- mount the toggle in the Header for desktop and mobile

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_686a92d7a63c8331970b1c6de4a822d6