### PR TITLE
Make LibreTranslate URL configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,6 @@ VITE_EMAILJS_TEMPLATE_ID=your_emailjs_template_id
 # Supabase configuration
 VITE_SUPABASE_URL=your_supabase_url
 VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
+
+# Optional translation API endpoint
+VITE_LIBRETRANSLATE_URL=https://libretranslate.de/translate

--- a/src/components/AgentIA.tsx
+++ b/src/components/AgentIA.tsx
@@ -1,7 +1,9 @@
 import { useState, useRef, useEffect } from "react";
 
 // Configuration API
-const LIBRETRANSLATE_URL = "https://libretranslate.de/translate";
+// The translation endpoint can be customized via environment variable.
+const LIBRETRANSLATE_URL =
+  import.meta.env.VITE_LIBRETRANSLATE_URL || "https://libretranslate.de/translate";
 
 // Langues supportées
 const SUPPORTED_LANGUAGES = {


### PR DESCRIPTION
## Summary
- use `VITE_LIBRETRANSLATE_URL` env variable in `AgentIA.tsx`
- document translation API variable in `.env.example`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_686a92e34f688331afd2ee0b7c7a8472