### PR TITLE
Respect reduced motion and tweak animation timing

### DIFF
--- a/src/components/Cube3D.tsx
+++ b/src/components/Cube3D.tsx
@@ -1,7 +1,11 @@
 import React, { useEffect, useRef } from 'react';
 import * as THREE from 'three';
 
-const Cube3D: React.FC = () => {
+interface Cube3DProps {
+  reduceMotion?: boolean;
+}
+
+const Cube3D: React.FC<Cube3DProps> = ({ reduceMotion = false }) => {
   const mountRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -72,17 +76,20 @@ const Cube3D: React.FC = () => {
     scene.add(particles);
 
     // Animation loop
-    const animate = () => {
-      requestAnimationFrame(animate);
+    let frameId: number;
 
-      cube.rotation.x += 0.004;
-      cube.rotation.y += 0.004;
-      line.rotation.x += 0.004;
-      line.rotation.y += 0.004;
-      particles.rotation.x += 0.002;
-      particles.rotation.y += 0.002;
+    const animate = () => {
+      if (!reduceMotion) {
+        cube.rotation.x += 0.004;
+        cube.rotation.y += 0.004;
+        line.rotation.x += 0.004;
+        line.rotation.y += 0.004;
+        particles.rotation.x += 0.002;
+        particles.rotation.y += 0.002;
+      }
 
       renderer.render(scene, camera);
+      frameId = requestAnimationFrame(animate);
     };
 
     animate();
@@ -100,6 +107,7 @@ const Cube3D: React.FC = () => {
       particlesGeometry.dispose();
       particlesMaterial.dispose();
       renderer.dispose();
+      if (frameId) cancelAnimationFrame(frameId);
     };
   }, []);
 

--- a/src/components/CursorEffect.tsx
+++ b/src/components/CursorEffect.tsx
@@ -1,9 +1,12 @@
 import React, { useEffect, useState } from 'react';
+import usePrefersReducedMotion from '../hooks/usePrefersReducedMotion';
 
 const CursorEffect: React.FC = () => {
   const [clicked, setClicked] = useState(false);
+  const reduceMotion = usePrefersReducedMotion();
 
   useEffect(() => {
+    if (reduceMotion) return;
     // Check if device has non-touch primary input
     // Don't apply effects on touch devices
     const isTouchDevice = () => {

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -3,10 +3,12 @@ import { motion } from 'framer-motion';
 import Typewriter from 'typewriter-effect';
 import Cube3D from './Cube3D';
 import { useTranslation } from 'react-i18next';
+import usePrefersReducedMotion from '../hooks/usePrefersReducedMotion';
 
 const Hero: React.FC = () => {
   const { t } = useTranslation();
   const [mounted, setMounted] = useState(false);
+  const reduceMotion = usePrefersReducedMotion();
 
   useEffect(() => {
     setMounted(true);
@@ -73,17 +75,21 @@ const Hero: React.FC = () => {
             className="text-xl md:text-2xl text-gray-300 min-h-[3rem] mb-8"
           >
             {mounted && (
-              <div className="flex items-center">
-                <Typewriter
-                  options={{
-                    strings: typewriterTexts,
-                    autoStart: true,
-                    loop: true,
-                    delay: 50,
-                    deleteSpeed: 30,
-                  }}
-                />
-              </div>
+              reduceMotion ? (
+                <span>{typewriterTexts[0]}</span>
+              ) : (
+                <div className="flex items-center">
+                  <Typewriter
+                    options={{
+                      strings: typewriterTexts,
+                      autoStart: true,
+                      loop: true,
+                      delay: 50,
+                      deleteSpeed: 30,
+                    }}
+                  />
+                </div>
+              )
             )}
           </motion.div>
 
@@ -120,11 +126,15 @@ const Hero: React.FC = () => {
         <motion.div
           initial={{ opacity: 0, scale: 0.8 }}
           animate={{ opacity: 1, scale: 1 }}
-          transition={{ duration: 0.8, delay: 0.5 }}
+          transition={{
+            duration: reduceMotion ? 0 : 0.5,
+            delay: reduceMotion ? 0 : 0.3,
+            ease: 'easeOut',
+          }}
           className="w-full md:w-2/5 flex justify-center md:justify-end"
         >
           <div className="relative w-64 h-64 animate-float">
-            <Cube3D />
+            <Cube3D reduceMotion={reduceMotion} />
           </div>
         </motion.div>
       </div>
@@ -132,13 +142,17 @@ const Hero: React.FC = () => {
       <motion.div
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
-        transition={{ delay: 1.2, duration: 1 }}
+        transition={{
+          delay: reduceMotion ? 0 : 1.2,
+          duration: reduceMotion ? 0 : 0.8,
+          ease: 'easeOut',
+        }}
         className="absolute bottom-10 left-1/2 transform -translate-x-1/2 flex flex-col items-center"
       >
         <div className="w-5 h-10 border-2 border-white rounded-full flex justify-center">
           <motion.div
-            animate={{ y: [0, 12, 0] }}
-            transition={{ repeat: Infinity, duration: 1.5 }}
+            animate={reduceMotion ? { y: 0 } : { y: [0, 12, 0] }}
+            transition={reduceMotion ? { duration: 0 } : { repeat: Infinity, duration: 1.2 }}
             className="w-1 h-2 bg-white rounded-full mt-2"
           />
         </div>

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { useInView } from 'react-intersection-observer';
 import { ArrowUpRight, Car, Utensils } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import usePrefersReducedMotion from '../hooks/usePrefersReducedMotion';
 
 interface Project {
   title: string;
@@ -14,6 +15,7 @@ interface Project {
 
 const Projects: React.FC = () => {
   const { t } = useTranslation();
+  const reduceMotion = usePrefersReducedMotion();
   const [ref, inView] = useInView({
     triggerOnce: true,
     threshold: 0.1,
@@ -54,7 +56,7 @@ const Projects: React.FC = () => {
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={inView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
-          transition={{ duration: 0.6 }}
+          transition={{ duration: reduceMotion ? 0 : 0.5, ease: 'easeOut' }}
           className="text-center mb-16"
         >
           <h2 className="text-3xl md:text-4xl font-bold mb-4">{t('projects.title')}</h2>
@@ -77,10 +79,10 @@ const Projects: React.FC = () => {
               className="project-card group relative overflow-hidden border border-gray-800 bg-darker"
             >
               <div className="relative h-72 overflow-hidden">
-                <img 
-                  src={project.image} 
-                  alt={project.title} 
-                  className="object-cover w-full h-full transition-transform duration-700 group-hover:scale-110"
+                <img
+                  src={project.image}
+                  alt={project.title}
+                  className="object-cover w-full h-full transition-transform duration-500 ease-out group-hover:scale-110"
                 />
                 <div className="absolute inset-0 bg-gradient-to-t from-darker to-transparent opacity-90"></div>
               </div>

--- a/src/hooks/usePrefersReducedMotion.ts
+++ b/src/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+const usePrefersReducedMotion = () => {
+  const [prefersReduced, setPrefersReduced] = useState(false);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const updatePreference = () => setPrefersReduced(mediaQuery.matches);
+
+    updatePreference();
+    mediaQuery.addEventListener('change', updatePreference);
+
+    return () => mediaQuery.removeEventListener('change', updatePreference);
+  }, []);
+
+  return prefersReduced;
+};
+
+export default usePrefersReducedMotion;

--- a/src/index.css
+++ b/src/index.css
@@ -93,7 +93,7 @@ body {
   width: 100%;
   height: 100%;
   transform-style: preserve-3d;
-  transition: transform 1s;
+  transition: transform 0.6s ease-out;
 }
 
 .cube__face {


### PR DESCRIPTION
## Summary
- shorten the cube CSS transition
- add hook for `prefers-reduced-motion`
- respect reduced motion in Hero and Projects sections
- disable effects in `CursorEffect` and `Cube3D`
- shorten some motion durations and add consistent easing

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_686a92f38ea08331b5e48a50e3451b94