### PR TITLE
Fix React hook warnings and cleanup ref usage

### DIFF
--- a/src/components/Cube3D.tsx
+++ b/src/components/Cube3D.tsx
@@ -5,7 +5,8 @@ const Cube3D: React.FC = () => {
   const mountRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!mountRef.current) return;
+    const mountNode = mountRef.current;
+    if (!mountNode) return;
 
     // Scene setup
     const scene = new THREE.Scene();
@@ -13,7 +14,7 @@ const Cube3D: React.FC = () => {
     const renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true });
     renderer.setSize(300, 300);
     renderer.setClearColor(0x000000, 0);
-    mountRef.current.appendChild(renderer.domElement);
+    mountNode.appendChild(renderer.domElement);
 
     // Light
     const ambientLight = new THREE.AmbientLight(0xffffff, 0.5);
@@ -89,8 +90,8 @@ const Cube3D: React.FC = () => {
 
     // Clean up
     return () => {
-      if (mountRef.current) {
-        mountRef.current.removeChild(renderer.domElement);
+      if (mountNode) {
+        mountNode.removeChild(renderer.domElement);
       }
       
       // Dispose resources

--- a/src/components/CursorEffect.tsx
+++ b/src/components/CursorEffect.tsx
@@ -1,7 +1,12 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 const CursorEffect: React.FC = () => {
   const [clicked, setClicked] = useState(false);
+  const clickedRef = useRef(false);
+
+  useEffect(() => {
+    clickedRef.current = clicked;
+  }, [clicked]);
 
   useEffect(() => {
     // Check if device has non-touch primary input
@@ -63,7 +68,7 @@ const CursorEffect: React.FC = () => {
         });
         
         link.addEventListener('mouseleave', () => {
-          if (!clicked) {
+          if (!clickedRef.current) {
             cursorDot.classList.remove('active');
           }
         });


### PR DESCRIPTION
## Summary
- store `mountRef.current` in a local variable for Cube3D cleanup
- keep cursor click state in a ref and sync it via a hook
- update lint dependencies

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686a92f5e850833187291c3f7d6916d6