### PR TITLE
Add localized article data

### DIFF
--- a/src/components/ArticlePage.tsx
+++ b/src/components/ArticlePage.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 
 const ArticlePage = () => {
   const { slug } = useParams();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const article = articles.find((a) => a.slug === slug);
 
   if (!article) {
@@ -14,11 +14,11 @@ const ArticlePage = () => {
   return (
     <section className="min-h-screen py-20 bg-dark text-white px-6 md:px-10">
       <div className="max-w-3xl mx-auto space-y-6">
-        <h1 className="text-3xl font-bold">{article.title}</h1>
+        <h1 className="text-3xl font-bold">{article.title[i18n.language] ?? article.title.en}</h1>
         <audio controls src={article.audio} className="w-full">
           Your browser does not support the audio element.
         </audio>
-        <p>{article.content}</p>
+        <p>{article.content[i18n.language] ?? article.content.en}</p>
         <Link to="/blog" className="text-blue-400 hover:underline">
           {t('blog.back')}
         </Link>

--- a/src/components/BlogPage.tsx
+++ b/src/components/BlogPage.tsx
@@ -3,7 +3,7 @@ import { articles } from '../data/articles';
 import { useTranslation } from 'react-i18next';
 
 const BlogPage = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   return (
     <section className="min-h-screen py-20 bg-dark text-white px-6 md:px-10">
       <div className="max-w-3xl mx-auto">
@@ -15,7 +15,7 @@ const BlogPage = () => {
                 to={`/blog/${article.slug}`}
                 className="text-xl text-blue-400 hover:underline"
               >
-                {article.title}
+                {article.title[i18n.language] ?? article.title.en}
               </Link>
             </li>
           ))}

--- a/src/data/articles.ts
+++ b/src/data/articles.ts
@@ -1,8 +1,8 @@
 export interface Article {
   id: string;
   slug: string;
-  title: string;
-  content: string;
+  title: Record<string, string>;
+  content: Record<string, string>;
   audio: string;
 }
 
@@ -12,8 +12,24 @@ export const articles: Article[] = [
   {
     id: '1',
     slug: 'premier-article',
-    title: 'Bienvenue sur mon blog',
-    content: `Ceci est le premier article de mon blog. Il contient un court extrait audio pour accompagner la lecture.`,
+    title: {
+      fr: 'Bienvenue sur mon blog',
+      en: 'Welcome to my blog',
+      es: 'Bienvenido a mi blog',
+      ja: '私のブログへようこそ',
+      zh: '欢迎来到我的博客',
+      ar: 'مرحبًا بكم في مدونتي',
+      th: 'ยินดีต้อนรับสู่บล็อกของฉัน',
+    },
+    content: {
+      fr: `Ceci est le premier article de mon blog. Il contient un court extrait audio pour accompagner la lecture.`,
+      en: `This is the first article of my blog. It contains a short audio snippet to accompany the reading.`,
+      es: `Este es el primer artículo de mi blog. Contiene un breve fragmento de audio para acompañar la lectura.`,
+      ja: `これは私のブログの最初の記事です。 読書を補う短いオーディオクリップが含まれています。`,
+      zh: `这是我的博客的第一篇文章。 它包含一个简短的音频片段以伴随阅读。`,
+      ar: `هذه هي أول مقالة في مدونتي. تحتوي على مقطع صوتي قصير لمرافقة القراءة.`,
+      th: `นี่คือบทความแรกของบล็อกของฉัน มีคลิปเสียงสั้นเพื่อประกอบการอ่าน`,
+    },
     audio: beepAudio
   }
 ];


### PR DESCRIPTION
## Summary
- add per-language fields for `Article`
- show article titles and content in the current language

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_686a80c7ba78833196239858d25f4f79