### PR TITLE
Add accessible label to LanguageSelector

### DIFF
--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -5,6 +5,7 @@ const LanguageSelector = () => (
     onChange={(e) => i18n.changeLanguage(e.target.value)}
     defaultValue={i18n.language}
     className="bg-black text-white border px-2 py-1 rounded ml-4"
+    aria-label="Select language"
   >
     <option value="fr">🇫🇷 Français</option>
     <option value="en">🇬🇧 English</option>


### PR DESCRIPTION
## Summary
- improve accessibility by adding an `aria-label` to the language selector

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_686aa46363b0833199548b6cf06f5d9f