### PR TITLE
Improve SEO metadata and GA config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,6 @@ VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
 
 # LibreTranslate configuration (optional translation API endpoint)
 VITE_LIBRETRANSLATE_URL=https://libretranslate.de/translate
+
+# Google Analytics configuration
+VITE_GA_ID=your_ga_measurement_id

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Required variables:
 - `VITE_SUPABASE_URL`
 - `VITE_SUPABASE_ANON_KEY`
 - `VITE_LIBRETRANSLATE_URL`
+- `VITE_GA_ID`
 
 `VITE_LIBRETRANSLATE_URL` should point to a LibreTranslate instance. You can
 use the public instance at `https://libretranslate.com/translate`, or run your

--- a/index.html
+++ b/index.html
@@ -5,18 +5,34 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Web developer portfolio of Karim Hammouche with projects, blog, and professional experience." />
+    <meta name="keywords" content="Karim Hammouche, web developer, portfolio, JavaScript, React" />
+    <meta name="author" content="Karim Hammouche" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://karimhammouche.com" />
+    <meta property="og:title" content="Karim Hammouche | Portfolio" />
+    <meta property="og:description" content="Web developer portfolio of Karim Hammouche with projects, blog, and professional experience." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://karimhammouche.com" />
+    <meta property="og:image" content="/vite.svg" />
     <title>Karim Hammouche | Portfolio</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 
     <!-- Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-T6RBR3M7Z1"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'G-T6RBR3M7Z1');
+    <script type="module">
+      const GA_ID = import.meta.env.VITE_GA_ID;
+      if (GA_ID) {
+        const gtagScript = document.createElement('script');
+        gtagScript.async = true;
+        gtagScript.src = `https://www.googletagmanager.com/gtag/js?id=${GA_ID}`;
+        document.head.appendChild(gtagScript);
+
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){ dataLayer.push(arguments); }
+        gtag('js', new Date());
+        gtag('config', GA_ID);
+      }
     </script>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- add SEO meta tags in `index.html`
- load Google Analytics ID from env variables
- document `VITE_GA_ID` in `.env.example` and `README`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_686aa593fa2c8331928e37e576036d89