### PR TITLE
Add typed i18n resources

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -30,7 +30,7 @@ const Hero: React.FC = () => {
 
 
   // Textes animés par langue
-  const typewriterTexts = t('hero.typewriter', { returnObjects: true }) as string[];
+  const typewriterTexts = t('hero.typewriter', { returnObjects: true });
 
   return (
     <section

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -23,7 +23,7 @@ const Projects: React.FC = () => {
   });
 
   const projectIcons = [<Car size={24} />, <Utensils size={24} />];
-  const rawProjects = t('projects.items', { returnObjects: true }) as Omit<Project, 'icon'>[];
+  const rawProjects = t('projects.items', { returnObjects: true });
   const projects: Project[] = rawProjects.map((proj, idx) => ({
     ...proj,
     icon: projectIcons[idx],

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -10,19 +10,21 @@ import zh from "./zh.json";
 import ar from "./ar.json";
 import th from "./th.json";
 
+export const resources = {
+  fr: { translation: fr },
+  en: { translation: en },
+  es: { translation: es },
+  ja: { translation: ja },
+  zh: { translation: zh },
+  ar: { translation: ar },
+  th: { translation: th },
+} as const;
+
 i18n
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
-    resources: {
-      fr: { translation: fr },
-      en: { translation: en },
-      es: { translation: es },
-      ja: { translation: ja },
-      zh: { translation: zh },
-      ar: { translation: ar },
-      th: { translation: th },
-    },
+    resources,
     fallbackLng: "fr",
     interpolation: {
       escapeValue: false,

--- a/src/i18n/react-i18next.d.ts
+++ b/src/i18n/react-i18next.d.ts
@@ -1,0 +1,9 @@
+import 'react-i18next';
+import { resources } from './index';
+
+declare module 'react-i18next' {
+  interface CustomTypeOptions {
+    defaultNS: 'translation';
+    resources: typeof resources.fr;
+  }
+}


### PR DESCRIPTION
## Summary
- export `resources` constant and use it for i18n init
- provide `react-i18next` type augmentation
- drop type casts in `Hero` and `Projects`

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars, no-empty, @typescript-eslint/no-explicit-any)*
- `npm run test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_686aa84887c083319a98491346e8a856