### PR TITLE
Make contact email clickable

### DIFF
--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -88,7 +88,12 @@ const Contact: React.FC = () => {
                   </div>
                   <div>
                     <h3 className="text-lg font-medium">Email</h3>
-                    <p className="text-gray-400">karim.hammouche1995@gmail.com</p>
+                    <a
+                      href="mailto:karim.hammouche1995@gmail.com"
+                      className="text-gray-400 hover:text-white transition-colors"
+                    >
+                      karim.hammouche1995@gmail.com
+                    </a>
                   </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- convert contact email plain text to a mailto link

## Testing
- `npm run lint` *(fails: Error while loading rule '@typescript-eslint/no-unused-expressions')*

------
https://chatgpt.com/codex/tasks/task_b_686b38bcfc588331812108451bb86e5a