### PR TITLE
Switch to Noto Sans font

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     <title>Karim Hammouche | Portfolio</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans&display=swap" rel="stylesheet">
 
     <!-- Google Analytics -->
     <script type="module">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,7 +5,7 @@ export default {
   theme: {
     extend: {
       fontFamily: {
-        sans: ['Space Grotesk', 'sans-serif'],
+        sans: ['Noto Sans', 'sans-serif'],
       },
       colors: {
         primary: '#ffffff',


### PR DESCRIPTION
## Summary
- use Noto Sans from Google Fonts
- update Tailwind font stack

## Testing
- `npm run lint` *(fails: TypeError about `no-unused-expressions` rule)*

------
https://chatgpt.com/codex/tasks/task_b_686b3a59d790833183e56a5a65d4d733