### PR TITLE
Add Universel resume option

### DIFF
--- a/public/cv-universal.pdf
+++ b/public/cv-universal.pdf
@@ -1,0 +1,108 @@
+%PDF-1.4
+1 0 obj
+<<
+/Title (Curriculum Vitae)
+/Author (Karim Hammouche)
+/Subject (CV)
+/Keywords (resume, cv, portfolio)
+/Creator (CV Generator)
+/Producer (Custom PDF Producer)
+/CreationDate (D:20250415120000)
+>>
+endobj
+2 0 obj
+<<
+/Type /Catalog
+/Pages 3 0 R
+>>
+endobj
+3 0 obj
+<<
+/Type /Pages
+/Count 1
+/Kids [4 0 R]
+>>
+endobj
+4 0 obj
+<<
+/Type /Page
+/Parent 3 0 R
+/Resources <<
+/Font <<
+/F1 5 0 R
+>>
+/ProcSet [/PDF /Text]
+>>
+/MediaBox [0 0 612 792]
+/Contents 6 0 R
+>>
+endobj
+5 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+>>
+endobj
+6 0 obj
+<< /Length 676 >>
+stream
+BT
+/F1 24 Tf
+72 720 Td
+(Karim Hammouche) Tj
+/F1 12 Tf
+0 -20 Td
+(karim.hammouche1995@gmail.com) Tj
+0 -40 Td
+/F1 16 Tf
+(Expérience Professionnelle) Tj
+/F1 12 Tf
+0 -20 Td
+(Rino Recycling - Brisbane) Tj
+0 -15 Td
+(Responsable Opérationnel, Nov. 2024 - Avril 2025) Tj
+0 -40 Td
+(Le Wagon Paris) Tj
+0 -15 Td
+(Développeur Web, 2023) Tj
+0 -40 Td
+(SNCF / Bouygues) Tj
+0 -15 Td
+(Électricien, 2017-2020) Tj
+0 -40 Td
+/F1 16 Tf
+(Entrepreneuriat) Tj
+/F1 12 Tf
+0 -20 Td
+(Turfu Driving - Location de véhicules) Tj
+0 -40 Td
+(0'240 - Fast-food) Tj
+0 -40 Td
+/F1 16 Tf
+(Compétences) Tj
+/F1 12 Tf
+0 -20 Td
+(HTML, CSS, Ruby on Rails, GitHub, Figma, CRM, Gestion de projet) Tj
+ET
+endstream
+endobj
+xref
+0 7
+0000000000 65535 f
+0000000009 00000 n
+0000000211 00000 n
+0000000260 00000 n
+0000000317 00000 n
+0000000459 00000 n
+0000000556 00000 n
+trailer
+<<
+/Size 7
+/Root 2 0 R
+/Info 1 0 R
+>>
+startxref
+1283
+%%EOF

--- a/src/components/ResumeSelector.tsx
+++ b/src/components/ResumeSelector.tsx
@@ -9,7 +9,8 @@ const resumes = [
   { label: 'IT - DevOps Engineer', file: '/cv-it-devops.pdf' },
   { label: 'CN - Product Manager', file: '/cv-cn-product.pdf' },
   { label: 'JA - Software Engineer', file: '/cv-ja-software.pdf' },
-  { label: 'PT - Cybersecurity', file: '/cv-pt-cyber.pdf' }
+  { label: 'PT - Cybersecurity', file: '/cv-pt-cyber.pdf' },
+  { label: 'Universel', file: '/cv-universal.pdf' }
 ];
 
 const ResumeSelector: React.FC = () => {


### PR DESCRIPTION
## Summary
- add Universel CV PDF
- list Universel CV option in `ResumeSelector`

## Testing
- `npm run lint` *(fails: Error while loading rule)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_686b4bae45a483319085f318d15334e4