### PR TITLE
Simplify EmailJS contact form

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,6 @@
 
 # EmailJS configuration
 VITE_EMAILJS_PUBLIC_KEY=w2jrqSt-GwSCQR7zM
-VITE_EMAILJS_SERVICE_ID=service_i30ke34
-VITE_EMAILJS_TEMPLATE_ID=template_2isjmxk
 
 # LibreTranslate configuration (optional translation API endpoint)
 VITE_LIBRETRANSLATE_URL=https://libretranslate.de/translate

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Environment Variables
 
-Copy `.env.example` to `.env` and populate the values for EmailJS:
+Copy `.env.example` to `.env` and populate your EmailJS public key:
 
 ```bash
 cp .env.example .env
@@ -15,8 +15,6 @@ cp .env.example .env
 Required variables:
 
 - `VITE_EMAILJS_PUBLIC_KEY`
-- `VITE_EMAILJS_SERVICE_ID`
-- `VITE_EMAILJS_TEMPLATE_ID`
 - `VITE_LIBRETRANSLATE_URL`
 - `VITE_GA_ID`
 

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,60 +1,15 @@
-import React, { useRef, useState, useEffect } from 'react';
+import React from 'react';
 import { motion } from 'framer-motion';
 import { containerVariants, itemVariants } from '../animationVariants';
 import { useInView } from 'react-intersection-observer';
-import { CheckCircle } from 'lucide-react';
-import CompactContactForm from './CompactContactForm';
-import emailjs from '@emailjs/browser';
+import ContactForm from './ContactForm';
 import SocialLinks from './SocialLinks';
 
-const EMAILJS_PUBLIC_KEY = import.meta.env.VITE_EMAILJS_PUBLIC_KEY!;
-const EMAILJS_SERVICE_ID = import.meta.env.VITE_EMAILJS_SERVICE_ID!;
-const EMAILJS_TEMPLATE_ID = import.meta.env.VITE_EMAILJS_TEMPLATE_ID!;
-
 const Contact: React.FC = () => {
-  const formRef = useRef<HTMLFormElement>(null);
-  const [loading, setLoading] = useState(false);
-  const [success, setSuccess] = useState(false);
-  const [error, setError] = useState('');
-
   const [ref, inView] = useInView({
     triggerOnce: true,
     threshold: 0.1,
   });
-
-  useEffect(() => {
-    emailjs.init(EMAILJS_PUBLIC_KEY);
-  }, []);
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-
-    if (!formRef.current) return;
-
-    try {
-      setLoading(true);
-      setError('');
-
-
-      const result = await emailjs.sendForm(
-        EMAILJS_SERVICE_ID,
-        EMAILJS_TEMPLATE_ID,
-        formRef.current
-      );
-
-      if (result.text === 'OK') {
-        setSuccess(true);
-        formRef.current.reset();
-      } else {
-        throw new Error('Failed to send email');
-      }
-    } catch (err) {
-      console.error(err);
-      setError('❌ Une erreur est survenue');
-    } finally {
-      setLoading(false);
-    }
-  };
 
 
 
@@ -111,19 +66,7 @@ const Contact: React.FC = () => {
           </motion.div>
 
           <motion.div variants={itemVariants}>
-            {success ? (
-              <div className="p-6 border border-gray-800 bg-darker text-center text-green-500 flex items-center justify-center space-x-2 rounded-2xl">
-                <CheckCircle size={20} />
-                <span>✅ Message envoyé avec succès</span>
-              </div>
-            ) : (
-              <CompactContactForm
-                formRef={formRef}
-                handleSubmit={handleSubmit}
-                loading={loading}
-                error={error}
-              />
-            )}
+            <ContactForm />
           </motion.div>
         </motion.div>
       </div>

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,0 +1,43 @@
+import { useRef, useState } from "react";
+import emailjs from "@emailjs/browser";
+
+export default function ContactForm() {
+  const form = useRef<HTMLFormElement | null>(null);
+  const [status, setStatus] = useState<"success" | "error" | "loading" | null>(null);
+
+  const sendEmail = (e: React.FormEvent) => {
+    e.preventDefault();
+    setStatus("loading");
+
+    emailjs
+      .sendForm(
+        "service_i30ke34",
+        "template_2isjmxk",
+        form.current!,
+        import.meta.env.VITE_EMAILJS_PUBLIC_KEY
+      )
+      .then(
+        () => {
+          setStatus("success");
+          form.current?.reset();
+        },
+        (error) => {
+          console.error("❌ Erreur EmailJS :", error);
+          setStatus("error");
+        }
+      );
+  };
+
+  return (
+    <form ref={form} onSubmit={sendEmail} className="space-y-4">
+      <input type="text" name="name" placeholder="Votre nom" required className="w-full p-2 border rounded" />
+      <input type="email" name="email" placeholder="Votre email" required className="w-full p-2 border rounded" />
+      <textarea name="message" placeholder="Votre message" required className="w-full p-2 border rounded" />
+      <button type="submit" disabled={status === 'loading'} className="px-4 py-2 bg-blue-500 text-white rounded">
+        {status === "loading" ? "Envoi en cours..." : "✈️ Envoyer le message"}
+      </button>
+      {status === "success" && <p style={{ color: "green" }}>✅ Message envoyé avec succès !</p>}
+      {status === "error" && <p style={{ color: "red" }}>❌ Une erreur est survenue.</p>}
+    </form>
+  );
+}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -3,7 +3,6 @@ import { motion } from 'framer-motion';
 import { itemVariants } from '../animationVariants';
 import Typewriter from 'typewriter-effect';
 import Cube3D from './Cube3D';
-import CompactContactForm from './CompactContactForm';
 import ResumeSelector from './ResumeSelector';
 import { useTranslation } from 'react-i18next';
 import usePrefersReducedMotion from '../hooks/usePrefersReducedMotion';


### PR DESCRIPTION
## Summary
- add simple `ContactForm` component using EmailJS
- simplify `Contact` page to use new form
- drop unused import in `Hero`
- keep only EmailJS public key in example env file
- update README instructions

## Testing
- `npm run lint` *(fails: cannot read property 'allowShortCircuit')*

------
https://chatgpt.com/codex/tasks/task_b_686b5646abcc833181f1fdadfcf4ca9e