### PR TITLE
Use env vars for EmailJS IDs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@
 
 # EmailJS configuration
 VITE_EMAILJS_PUBLIC_KEY=w2jrqSt-GwSCQR7zM
+VITE_EMAILJS_SERVICE_ID=your_emailjs_service_id
+VITE_EMAILJS_TEMPLATE_ID=your_emailjs_template_id
 
 # LibreTranslate configuration (optional translation API endpoint)
 VITE_LIBRETRANSLATE_URL=https://libretranslate.de/translate

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Environment Variables
 
-Copy `.env.example` to `.env` and populate your EmailJS public key:
+Copy `.env.example` to `.env` and populate your EmailJS configuration:
 
 ```bash
 cp .env.example .env
@@ -15,6 +15,8 @@ cp .env.example .env
 Required variables:
 
 - `VITE_EMAILJS_PUBLIC_KEY`
+- `VITE_EMAILJS_SERVICE_ID`
+- `VITE_EMAILJS_TEMPLATE_ID`
 - `VITE_LIBRETRANSLATE_URL`
 - `VITE_GA_ID`
 

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,6 +1,9 @@
 import { useRef, useState } from "react";
 import emailjs from "@emailjs/browser";
 
+const serviceId = import.meta.env.VITE_EMAILJS_SERVICE_ID!;
+const templateId = import.meta.env.VITE_EMAILJS_TEMPLATE_ID!;
+
 export default function ContactForm() {
   const form = useRef<HTMLFormElement | null>(null);
   const [status, setStatus] = useState<"success" | "error" | "loading" | null>(null);
@@ -11,8 +14,8 @@ export default function ContactForm() {
 
     emailjs
       .sendForm(
-        "service_i30ke34",
-        "template_2isjmxk",
+        serviceId,
+        templateId,
         form.current!,
         import.meta.env.VITE_EMAILJS_PUBLIC_KEY
       )


### PR DESCRIPTION
## Summary
- add EmailJS service and template IDs to `.env.example`
- document the new environment variables in README
- load service and template IDs via `import.meta.env` in `ContactForm`

## Testing
- `npm run lint` *(fails: Cannot read properties of undefined ...)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_686b78efb24083318b4828b814214e5f