### PR TITLE
Fix EmailJS sendForm parameters

### DIFF
--- a/src/components/CompactContactForm.tsx
+++ b/src/components/CompactContactForm.tsx
@@ -27,7 +27,11 @@ const CompactContactForm: React.FC<CompactContactFormProps> = ({
   const [internalError, setInternalError] = useState('');
 
   useEffect(() => {
-    emailjs.init(EMAILJS_PUBLIC_KEY);
+    try {
+      emailjs.init(EMAILJS_PUBLIC_KEY);
+    } catch (err) {
+      console.error('EmailJS init error', err);
+    }
   }, []);
 
   const internalHandleSubmit = async (e: React.FormEvent) => {
@@ -41,8 +45,10 @@ const CompactContactForm: React.FC<CompactContactFormProps> = ({
       const result = await emailjs.sendForm(
         EMAILJS_SERVICE_ID,
         EMAILJS_TEMPLATE_ID,
-        internalFormRef.current
+        internalFormRef.current,
+        EMAILJS_PUBLIC_KEY
       );
+      console.log('EmailJS result:', result);
       if (result.text === 'OK') {
         setSuccess(true);
         internalFormRef.current.reset();


### PR DESCRIPTION
## Summary
- ensure EmailJS public key is initialized safely
- pass public key to `emailjs.sendForm`
- log success result for easier debugging

## Testing
- `npm install`
- `npm run lint` *(fails: Error while loading rule `@typescript-eslint/no-unused-expressions`)*

------
https://chatgpt.com/codex/tasks/task_b_686b8750b9e88331875cebb1c9c72a05