### PR TITLE
Replace Cube with Moon 3D component

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { itemVariants } from '../animationVariants';
 import Typewriter from 'typewriter-effect';
-import Cube3D from './Cube3D';
+import Moon3D from './Moon3D';
 import ResumeSelector from './ResumeSelector';
 import { useTranslation } from 'react-i18next';
 import usePrefersReducedMotion from '../hooks/usePrefersReducedMotion';
@@ -117,7 +117,7 @@ const Hero: React.FC = () => {
           className="w-full md:w-2/5 flex justify-center md:justify-end"
         >
           <div className="relative w-64 h-64 animate-float">
-            <Cube3D reduceMotion={reduceMotion} />
+            <Moon3D reduceMotion={reduceMotion} />
           </div>
         </motion.div>
       </div>

--- a/src/components/Moon3D.tsx
+++ b/src/components/Moon3D.tsx
@@ -1,0 +1,39 @@
+import React, { useRef } from 'react';
+import { Canvas, useFrame } from '@react-three/fiber';
+import { OrbitControls, Edges } from '@react-three/drei';
+import * as THREE from 'three';
+
+interface Moon3DProps {
+  reduceMotion?: boolean;
+}
+
+const SpinningSphere: React.FC<{ reduceMotion: boolean }> = ({ reduceMotion }) => {
+  const meshRef = useRef<THREE.Mesh>(null!);
+  useFrame(() => {
+    if (!reduceMotion) {
+      meshRef.current.rotation.y += 0.01;
+      meshRef.current.rotation.z += 0.002;
+    }
+  });
+
+  return (
+    <mesh ref={meshRef}>
+      <sphereGeometry args={[1.5, 32, 32]} />
+      <meshPhongMaterial color={0xffffff} transparent opacity={0.15} />
+      <Edges scale={1} color="white" />
+    </mesh>
+  );
+};
+
+const Moon3D: React.FC<Moon3DProps> = ({ reduceMotion = false }) => (
+  <div className="w-full h-64 sm:h-96 md:h-full">
+    <Canvas camera={{ position: [0, 0, 5] }}>
+      <ambientLight intensity={0.5} />
+      <directionalLight position={[5, 5, 5]} intensity={0.5} />
+      <SpinningSphere reduceMotion={reduceMotion} />
+      <OrbitControls />
+    </Canvas>
+  </div>
+);
+
+export default Moon3D;


### PR DESCRIPTION
## Summary
- add new `Moon3D` component
- swap `Cube3D` with `Moon3D` in the hero section

## Testing
- `npm run lint` *(fails: Unexpected any in App.tsx)*
- `node tests/scrollToHash.cjs` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_b_687295709d088331806c0ff5f1f6679a