### PR TITLE
Improve Moon 3D component stability

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,28 @@
+import { Component, ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+interface State {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown) {
+    console.error('Canvas error:', error);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback ?? <div>Une erreur est survenue.</div>;
+    }
+    return this.props.children;
+  }
+}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -2,7 +2,11 @@ import React, { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { itemVariants } from '../animationVariants';
 import Typewriter from 'typewriter-effect';
-import Moon3D from './Moon3D';
+import { Canvas } from '@react-three/fiber';
+import { Suspense } from 'react';
+import { OrbitControls } from '@react-three/drei';
+import Moon from './Moon';
+import ErrorBoundary from './ErrorBoundary';
 import ResumeSelector from './ResumeSelector';
 import { useTranslation } from 'react-i18next';
 import usePrefersReducedMotion from '../hooks/usePrefersReducedMotion';
@@ -110,7 +114,16 @@ const Hero: React.FC = () => {
           className="w-full md:w-2/5 flex justify-center md:justify-end"
         >
           <div className="relative w-64 h-64 animate-float">
-            <Moon3D reduceMotion={reduceMotion} />
+            <ErrorBoundary fallback={<div className="text-red-500">Erreur de chargement de la Lune</div>}>
+              <Canvas camera={{ position: [0, 0, 5], fov: 45 }} style={{ background: 'transparent' }}>
+                <ambientLight intensity={0.5} />
+                <directionalLight position={[5, 5, 5]} intensity={1} />
+                <Suspense fallback={<div className="text-gray-400">Chargement de la Lune...</div>}>
+                  <Moon />
+                  <OrbitControls enableZoom={false} />
+                </Suspense>
+              </Canvas>
+            </ErrorBoundary>
             <div className={`planet-info${mounted ? ' show' : ''}`}>
               <h2>Lune</h2>
               <p>Seul satellite naturel de la Terre, la Lune influence nos marées et notre culture.</p>

--- a/src/components/Moon.tsx
+++ b/src/components/Moon.tsx
@@ -1,0 +1,23 @@
+import { useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { useGLTF } from '@react-three/drei';
+import { Mesh } from 'three';
+
+export default function Moon(props: JSX.IntrinsicElements['group']) {
+  const moonRef = useRef<Mesh>(null);
+  const { scene } = useGLTF('/moon/scene.gltf');
+
+  useFrame(() => {
+    if (moonRef.current) {
+      moonRef.current.rotation.y += 0.001;
+    }
+  });
+
+  return (
+    <group ref={moonRef} {...props} dispose={null}>
+      <primitive object={scene} scale={2} position={[0, 0, 0]} />
+    </group>
+  );
+}
+
+useGLTF.preload('/moon/scene.gltf');


### PR DESCRIPTION
## Summary
- add ErrorBoundary component for safe rendering
- implement Moon glTF component
- render Moon inside Canvas with Suspense and error fallback
- update Hero section to use the new Moon component

## Testing
- `npm run lint`
- `npm run build` *(fails: Could not resolve "./audio" from "src/data/articles.ts")*

------
https://chatgpt.com/codex/tasks/task_b_687360e743b483318d5992d221301c54