### PR TITLE
Persist theme across reloads

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,9 +40,8 @@
       (function() {
         const stored = localStorage.getItem('theme');
         const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        if (stored === 'dark' || (!stored && prefersDark)) {
-          document.body.classList.add('dark');
-        }
+        const theme = stored || (prefersDark ? 'dark' : 'light');
+        document.documentElement.className = theme;
       })();
     </script>
     <div id="root"></div>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -2,11 +2,11 @@ import { Moon, Sun } from 'lucide-react';
 import { useTheme } from '../hooks/useTheme';
 
 const ThemeToggle = () => {
-  const { theme, toggle } = useTheme();
+  const { theme, toggleTheme } = useTheme();
   const Icon = theme === 'dark' ? Sun : Moon;
   return (
     <button
-      onClick={toggle}
+      onClick={toggleTheme}
       aria-label="Toggle theme"
       className="p-2 rounded border border-gray-300 dark:border-gray-700 bg-white text-black dark:bg-black dark:text-white"
     >

--- a/src/hooks/useTheme.tsx
+++ b/src/hooks/useTheme.tsx
@@ -3,7 +3,7 @@ import React, { createContext, useContext, useEffect, useState } from 'react';
 export type Theme = 'light' | 'dark';
 interface ThemeContextValue {
   theme: Theme;
-  toggle: () => void;
+  toggleTheme: () => void;
 }
 
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
@@ -11,23 +11,20 @@ const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [theme, setTheme] = useState<Theme>(() => {
     if (typeof window !== 'undefined') {
-      const stored = localStorage.getItem('theme');
-      if (stored === 'light' || stored === 'dark') return stored;
-      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      return prefersDark ? 'dark' : 'light';
+      return (localStorage.getItem('theme') as Theme) || 'light';
     }
     return 'light';
   });
 
   useEffect(() => {
-    document.body.classList.toggle('dark', theme === 'dark');
+    document.documentElement.className = theme;
     localStorage.setItem('theme', theme);
   }, [theme]);
 
-  const toggle = () => setTheme(prev => (prev === 'dark' ? 'light' : 'dark'));
+  const toggleTheme = () => setTheme(prev => (prev === 'dark' ? 'light' : 'dark'));
 
   return (
-    <ThemeContext.Provider value={{ theme, toggle }}>
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
       {children}
     </ThemeContext.Provider>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -11,11 +11,15 @@ html {
 }
 
 body {
-  @apply bg-white text-black font-sans m-0 p-0 overflow-x-hidden;
+  @apply font-sans m-0 p-0 overflow-x-hidden;
   opacity: 1 !important;
 }
 
-body.dark {
+html.light {
+  @apply bg-white text-black;
+}
+
+html.dark {
   @apply bg-black text-white;
 }
 


### PR DESCRIPTION
## Summary
- manage theme using global HTML classes
- provide toggle via `useTheme` hook
- update theme toggle component to use the new API
- adjust global styles for `html.light` and `html.dark`
- initialize theme on page load

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6873828c7680833185f2021a6f7db15a