### PR TITLE
Add ImportMetaEnv typing for Vite env vars

### DIFF
--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,13 @@
 /// <reference types="vite/client" />
+
+export interface ImportMetaEnv {
+  readonly VITE_EMAILJS_PUBLIC_KEY: string;
+  readonly VITE_EMAILJS_SERVICE_ID: string;
+  readonly VITE_EMAILJS_TEMPLATE_ID: string;
+  readonly VITE_LIBRETRANSLATE_URL: string;
+  readonly VITE_GA_ID: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- type environment variables in `src/vite-env.d.ts`

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_687385c53e5c8331bef2c4ca7dce98b9