### PR TITLE
Fix blog/ article dark theme classes

### DIFF
--- a/src/components/ArticlePage.tsx
+++ b/src/components/ArticlePage.tsx
@@ -12,7 +12,7 @@ const ArticlePage = () => {
   }
 
   return (
-    <section className="min-h-screen py-20 bg-dark text-white px-6 md:px-10">
+    <section className="min-h-screen py-20 bg-light dark:bg-dark text-black dark:text-white px-6 md:px-10">
       <div className="max-w-3xl mx-auto space-y-6">
         <h1 className="text-3xl font-bold">{article.title[i18n.language] ?? article.title.en}</h1>
         <audio controls src={article.audio} className="w-full">

--- a/src/components/BlogPage.tsx
+++ b/src/components/BlogPage.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 const BlogPage = () => {
   const { t, i18n } = useTranslation();
   return (
-    <section className="min-h-screen py-20 bg-dark text-white px-6 md:px-10">
+    <section className="min-h-screen py-20 bg-light dark:bg-dark text-black dark:text-white px-6 md:px-10">
       <div className="max-w-3xl mx-auto">
         <h1 className="text-3xl font-bold mb-8">{t('blog.title')}</h1>
         <ul className="space-y-6">


### PR DESCRIPTION
## Summary
- update BlogPage section to support light/dark themes
- update ArticlePage section to support light/dark themes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687394874c648331b8290ff1eb9c1b55