### PR TITLE
Fix dark scheme

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -20,6 +20,7 @@ html.light {
 }
 
 html.dark {
+  color-scheme: dark;
   @apply bg-black text-white;
 }
 


### PR DESCRIPTION
## Summary
- apply `color-scheme: dark` when `.dark` class is on `html`

## Testing
- `npm install --silent`
- `npm run lint`
- `node tests/scrollToHash.cjs`


------
https://chatgpt.com/codex/tasks/task_b_68739487eed88331a75ea90f17b5be6b