### PR TITLE
Move theme script to head

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,15 @@
     <meta property="og:url" content="https://karimhammouche.com" />
     <meta property="og:image" content="/vite.svg" />
     <title>Karim Hammouche | Portfolio</title>
+    <script>
+      (function () {
+        const stored = localStorage.getItem('theme');
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const theme = stored || (prefersDark ? 'dark' : 'light');
+        document.documentElement.classList.toggle('dark', theme === 'dark');
+        localStorage.setItem('theme', theme);
+      })();
+    </script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans&display=swap" rel="stylesheet">
@@ -36,15 +45,6 @@
     </script>
   </head>
   <body>
-    <script>
-      (function() {
-        const stored = localStorage.getItem('theme');
-        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        const theme = stored || (prefersDark ? 'dark' : 'light');
-        document.documentElement.classList.toggle('dark', theme === 'dark');
-        localStorage.setItem('theme', theme);
-      })();
-    </script>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>


### PR DESCRIPTION
## Summary
- move theme detection script into `<head>` before external styles

## Testing
- `node tests/scrollToHash.cjs`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68739f932c688331942876320b0ca8f0