### PR TITLE
Implement useDarkMode hook and cleanup theme logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,6 @@
         const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
         const theme = stored || (prefersDark ? 'dark' : 'light');
         document.documentElement.classList.toggle('dark', theme === 'dark');
-        localStorage.setItem('theme', theme);
       })();
     </script>
     <div id="root"></div>

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react-vertical-timeline-component';
 import 'react-vertical-timeline-component/style.min.css';
 import { Briefcase } from 'lucide-react';
-import { useTheme } from '../hooks/useTheme';
+import useDarkMode from '../hooks/useDarkMode';
 
 interface ExperienceItem {
   title: string;
@@ -24,7 +24,7 @@ const Experience: React.FC = () => {
     triggerOnce: true,
     threshold: 0.1,
   });
-  const { theme } = useTheme();
+  const [theme] = useDarkMode();
 
   const experienceItems: ExperienceItem[] = t('experience.items', { returnObjects: true }).map((exp: { title: string; company: string; dates: string; tasks?: string[] }) => ({
     title: exp.title,

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,8 +1,8 @@
 import { Moon, Sun } from 'lucide-react';
-import { useTheme } from '../hooks/useTheme';
+import useDarkMode from '../hooks/useDarkMode';
 
 const ThemeToggle = () => {
-  const { theme, toggleTheme } = useTheme();
+  const [theme, toggleTheme] = useDarkMode();
   const Icon = theme === 'dark' ? Sun : Moon;
   return (
     <button

--- a/src/hooks/useDarkMode.ts
+++ b/src/hooks/useDarkMode.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+const useDarkMode = (): [Theme, () => void] => {
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('theme') as Theme | null;
+      if (stored) return stored;
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      return prefersDark ? 'dark' : 'light';
+    }
+    return 'light';
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.toggle('dark', theme === 'dark');
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme(prev => (prev === 'dark' ? 'light' : 'dark'));
+
+  return [theme, toggleTheme];
+};
+
+export default useDarkMode;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,14 +4,11 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './App.tsx';
 import './index.css';
 import './i18n';
-import { ThemeProvider } from './hooks/useTheme';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <ThemeProvider>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    </ThemeProvider>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- add `useDarkMode` hook for dark mode management
- update `ThemeToggle` and `Experience` components to use the new hook
- remove context provider usage from `main.tsx`
- simplify theme initialization script in `index.html`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68739f97e7f48331b68d3a1c2ea19a96