### PR TITLE
Improve theme classes handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
         const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
         const theme = stored || (prefersDark ? 'dark' : 'light');
         document.documentElement.classList.toggle('dark', theme === 'dark');
+        document.documentElement.classList.toggle('light', theme === 'light');
         localStorage.setItem('theme', theme);
       })();
     </script>

--- a/src/hooks/useTheme.tsx
+++ b/src/hooks/useTheme.tsx
@@ -21,11 +21,8 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
 
   useLayoutEffect(() => {
     const root = document.documentElement;
-    if (theme === 'dark') {
-      root.classList.add('dark');
-    } else {
-      root.classList.remove('dark');
-    }
+    root.classList.toggle('dark', theme === 'dark');
+    root.classList.toggle('light', theme === 'light');
     localStorage.setItem('theme', theme);
   }, [theme]);
 

--- a/src/index.css
+++ b/src/index.css
@@ -2,10 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  color-scheme: light;
-}
-
 html {
   scroll-behavior: smooth;
 }
@@ -16,6 +12,7 @@ body {
 }
 
 html.light {
+  color-scheme: light;
   @apply bg-white text-black;
 }
 


### PR DESCRIPTION
## Summary
- add `.light` class handling in initialization script
- toggle both dark and light classes in `useTheme`
- tie base `color-scheme` to light/dark classes in `index.css`

## Testing
- `npm run lint`
- `node tests/scrollToHash.cjs`


------
https://chatgpt.com/codex/tasks/task_b_68739f9d45608331a261c59bd142ae54