### PR TITLE
Update project descriptions and grid display

### DIFF
--- a/src/components/ProjectCardsGrid.tsx
+++ b/src/components/ProjectCardsGrid.tsx
@@ -4,7 +4,7 @@ import ProjectCard from './ProjectCard';
 import { projects } from '../data/projects';
 
 const ProjectCardsGrid: React.FC = () => {
-  const { t } = useTranslation('projects');
+  const { t, i18n } = useTranslation('projects');
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -12,7 +12,7 @@ const ProjectCardsGrid: React.FC = () => {
         <ProjectCard
           key={project.id}
           title={t(`${project.id}.title`)}
-          description={t(`${project.id}.description`)}
+          description={project.description[i18n.language]}
           image={project.image}
           tags={project.tags}
           link={project.url}

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -2,6 +2,10 @@ export interface Project {
   id: string;
   image: string;
   tags: string[];
+  description: {
+    en: string;
+    fr: string;
+  };
   url?: string;
 }
 
@@ -10,48 +14,80 @@ export const projects: Project[] = [
     id: 'kr',
     image: 'https://images.pexels.com/photos/6693638/pexels-photo-6693638.jpeg',
     tags: ['SaaS', 'AI', 'Automation', 'e-commerce', 'Freelance'],
+    description: {
+      en: 'Tech and e-commerce services with automation expertise.',
+      fr: 'Services tech et e-commerce avec expertise en automatisation.'
+    },
     url: ''
   },
   {
     id: 'felizbella',
     image: 'https://images.pexels.com/photos/2622187/pexels-photo-2622187.jpeg',
     tags: ['Cosmetics', 'Shopify', 'Branding', 'Marketing'],
+    description: {
+      en: 'E-commerce and branding project for a natural cosmetics line.',
+      fr: 'Projet e-commerce et branding pour une ligne de cosmétiques naturels.'
+    },
     url: ''
   },
   {
     id: 'khh',
     image: 'https://images.pexels.com/photos/21273694/pexels-photo-21273694.jpeg',
     tags: ['Real Estate', 'Airbnb', 'Automation', 'Invest'],
+    description: {
+      en: 'Experimental and cultural side-projects with web hosting and design.',
+      fr: 'Projets expérimentaux et culturels avec hébergement et design.'
+    },
     url: ''
   },
   {
     id: 'domaine',
     image: 'https://images.pexels.com/photos/5529519/pexels-photo-5529519.jpeg',
     tags: ['Agriculture', 'Organic', 'Morocco', 'Eco'],
+    description: {
+      en: 'Local organic farming venture with digital branding support.',
+      fr: 'Exploitation agricole biologique locale avec soutien digital.'
+    },
     url: ''
   },
   {
     id: 'fastfood',
     image: 'https://images.pexels.com/photos/3220617/pexels-photo-3220617.jpeg',
     tags: ['Restaurant', 'Management', 'Marketing', 'Finance'],
+    description: {
+      en: 'Management and marketing for a restaurant franchise.',
+      fr: 'Gestion et marketing pour une franchise de restauration rapide.'
+    },
     url: ''
   },
   {
     id: 'turfu',
     image: 'https://images.pexels.com/photos/70912/pexels-photo-70912.jpeg',
     tags: ['Rental', 'Digital', 'CRM', 'Startup'],
+    description: {
+      en: 'UX/UI and branding for an innovative driving school.',
+      fr: 'UX/UI et branding pour une auto-école innovante.'
+    },
     url: ''
   },
   {
     id: 'tlfh',
     image: 'https://images.pexels.com/photos/6169661/pexels-photo-6169661.jpeg',
     tags: ['Logistics', 'Transport', 'B2B', 'Ops'],
+    description: {
+      en: 'Tech and visual consulting for a fashion platform.',
+      fr: 'Conseil tech et visuel pour une plateforme de mode.'
+    },
     url: ''
   },
   {
     id: 'wash',
     image: 'https://images.pexels.com/photos/6872572/pexels-photo-6872572.jpeg',
     tags: ['Car wash', 'Service', 'Process', 'Local'],
+    description: {
+      en: 'Website redesign and SEO for a local laundry service.',
+      fr: 'Refonte de site et SEO pour un service de blanchisserie local.'
+    },
     url: ''
   }
 ];

--- a/src/i18n/projects/en.json
+++ b/src/i18n/projects/en.json
@@ -1,34 +1,26 @@
 {
   "kr": {
-    "title": "KR Global Solutions",
-    "description": "Tech and e-commerce services with automation expertise."
+    "title": "KR Global Solutions"
   },
   "felizbella": {
-    "title": "FelizBella",
-    "description": "E-commerce and branding project for a natural cosmetics line."
+    "title": "FelizBella"
   },
   "khh": {
-    "title": "KHH Global Projects",
-    "description": "Experimental and cultural side-projects with web hosting and design."
+    "title": "KHH Global Projects"
   },
   "domaine": {
-    "title": "Domaine Harrach",
-    "description": "Local organic farming venture with digital branding support."
+    "title": "Domaine Harrach"
   },
   "fastfood": {
-    "title": "Fast-Food Restaurant",
-    "description": "Management and marketing for a restaurant franchise."
+    "title": "Fast-Food Restaurant"
   },
   "turfu": {
-    "title": "Turfu Driving",
-    "description": "UX/UI and branding for an innovative driving school."
+    "title": "Turfu Driving"
   },
   "tlfh": {
-    "title": "TLFH",
-    "description": "Tech and visual consulting for a fashion platform."
+    "title": "TLFH"
   },
   "wash": {
-    "title": "Wash Center",
-    "description": "Website redesign and SEO for a local laundry service."
+    "title": "Wash Center"
   }
 }

--- a/src/i18n/projects/fr.json
+++ b/src/i18n/projects/fr.json
@@ -1,34 +1,26 @@
 {
   "kr": {
-    "title": "KR Global Solutions",
-    "description": "Services tech et e-commerce avec expertise en automatisation."
+    "title": "KR Global Solutions"
   },
   "felizbella": {
-    "title": "FelizBella",
-    "description": "Projet e-commerce et branding pour une ligne de cosmétiques naturels."
+    "title": "FelizBella"
   },
   "khh": {
-    "title": "KHH Global Projects",
-    "description": "Projets expérimentaux et culturels avec hébergement et design."
+    "title": "KHH Global Projects"
   },
   "domaine": {
-    "title": "Domaine Harrach",
-    "description": "Exploitation agricole biologique locale avec soutien digital."
+    "title": "Domaine Harrach"
   },
   "fastfood": {
-    "title": "Restaurant Fast-food",
-    "description": "Gestion et marketing pour une franchise de restauration rapide."
+    "title": "Restaurant Fast-food"
   },
   "turfu": {
-    "title": "Turfu Driving",
-    "description": "UX/UI et branding pour une auto-école innovante."
+    "title": "Turfu Driving"
   },
   "tlfh": {
-    "title": "TLFH",
-    "description": "Conseil tech et visuel pour une plateforme de mode."
+    "title": "TLFH"
   },
   "wash": {
-    "title": "Wash Center",
-    "description": "Refonte de site et SEO pour un service de blanchisserie local."
+    "title": "Wash Center"
   }
 }


### PR DESCRIPTION
## Summary
- augment `Project` interface with bilingual `description`
- move project descriptions from i18n files into `projects.ts`
- show project descriptions based on current language

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6873a8c663948331869a98136074f403