### PR TITLE
Add reusable AudioPlayer component

### DIFF
--- a/src/components/ArticlePage.tsx
+++ b/src/components/ArticlePage.tsx
@@ -1,6 +1,7 @@
 import { useParams, Link } from 'react-router-dom';
 import { articles } from '../data/articles';
 import { useTranslation } from 'react-i18next';
+import AudioPlayer from './AudioPlayer';
 
 const ArticlePage = () => {
   const { slug } = useParams();
@@ -15,9 +16,7 @@ const ArticlePage = () => {
     <section className="min-h-screen py-20 bg-light dark:bg-dark text-black dark:text-white px-6 md:px-10">
       <div className="max-w-3xl mx-auto space-y-6">
         <h1 className="text-3xl font-bold">{article.title[i18n.language] ?? article.title.en}</h1>
-        <audio controls src={article.audio} className="w-full">
-          Your browser does not support the audio element.
-        </audio>
+        <AudioPlayer src={article.audio} className="w-full" />
         <p>{article.content[i18n.language] ?? article.content.en}</p>
         <Link to="/blog" className="text-blue-400 hover:underline">
           {t('blog.back')}

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+interface AudioPlayerProps {
+  src: string;
+  controls?: boolean;
+  autoPlay?: boolean;
+  className?: string;
+  ariaLabel?: string;
+}
+
+const AudioPlayer: React.FC<AudioPlayerProps> = ({
+  src,
+  controls = true,
+  autoPlay = false,
+  className,
+  ariaLabel,
+}) => (
+  <audio
+    controls={controls}
+    autoPlay={autoPlay}
+    className={className}
+    aria-label={ariaLabel}
+  >
+    <source src={src} />
+    Your browser does not support the audio element.
+  </audio>
+);
+
+export default AudioPlayer;


### PR DESCRIPTION
## Summary
- create accessible `AudioPlayer` component
- use `AudioPlayer` in `ArticlePage`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6873df621b388331bec85ec0f39d65d3