### PR TITLE
Add animated blog components and pages

### DIFF
--- a/src/components/blog/AudioPlayer.tsx
+++ b/src/components/blog/AudioPlayer.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface AudioPlayerProps {
+  src: string;
+}
+
+const AudioPlayer: React.FC<AudioPlayerProps> = ({ src }) => (
+  <audio
+    controls
+    className="w-full h-10 md:h-8 bg-gray-200 dark:bg-gray-800 rounded"
+  >
+    <source src={src} type="audio/mpeg" />
+    Your browser does not support the audio element.
+  </audio>
+);
+
+export default AudioPlayer;

--- a/src/components/blog/BlogCard.tsx
+++ b/src/components/blog/BlogCard.tsx
@@ -1,0 +1,25 @@
+import { Link } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import type { BlogArticle } from '@/data/blogData';
+
+interface BlogCardProps {
+  article: BlogArticle;
+}
+
+const BlogCard = ({ article }: BlogCardProps) => (
+  <motion.article
+    initial={{ opacity: 0, y: 20 }}
+    whileInView={{ opacity: 1, y: 0 }}
+    viewport={{ once: true }}
+    transition={{ duration: 0.4 }}
+    className="border border-gray-300 dark:border-gray-700 bg-white dark:bg-darker rounded-lg p-4 shadow hover:shadow-lg"
+  >
+    <Link to={`/blog/${article.slug}`} className="block space-y-2">
+      <h3 className="text-xl font-semibold">{article.title}</h3>
+      <p className="text-sm text-gray-500">{article.date}</p>
+      <p className="text-gray-700 dark:text-gray-300">{article.excerpt}</p>
+    </Link>
+  </motion.article>
+);
+
+export default BlogCard;

--- a/src/data/blogData.ts
+++ b/src/data/blogData.ts
@@ -1,39 +1,48 @@
-export interface BlogSection {
-  heading?: string;
-  text: string;
-}
+import { beepAudio } from './audio';
 
-export interface BlogPost {
-  title: string;
+export interface BlogArticle {
   slug: string;
+  title: string;
   date: string;
-  audioUrl?: string;
-  pdfLinks?: Record<string, string>;
-  sections: BlogSection[];
+  excerpt: string;
+  contentFR: string;
+  contentEN: string;
+  quote: string;
+  audioUrl: string;
+  pdfFR: string;
+  pdfEN: string;
 }
 
-export const blogPosts: BlogPost[] = [
+export const blogArticles: BlogArticle[] = [
   {
-    title: 'Méthode 4D',
     slug: 'methode-4d',
+    title: 'Méthode 4D',
     date: '2024-06-01',
-    audioUrl:
-      'https://supabase.example.com/storage/v1/object/public/blog/methode-4d.mp3',
-    pdfLinks: {
-      fr: '/methode-4d-fr.pdf',
-      en: '/methode-4d-en.pdf'
-    },
-    sections: [
-      {
-        heading: 'Introduction',
-        text:
-          'La méthode 4D aide à clarifier, déléguer, différer puis faire disparaître les tâches inutiles.'
-      },
-      {
-        heading: 'English',
-        text:
-          'The 4D method helps clarify, delegate, defer and finally delete useless tasks.'
-      }
-    ]
+    excerpt: 'La méthode 4D aide à organiser efficacement les tâches.',
+    contentFR:
+      "La méthode 4D aide à clarifier, déléguer, différer puis faire disparaître les tâches inutiles.",
+    contentEN:
+      'The 4D method helps clarify, delegate, defer and finally delete useless tasks.',
+    quote: "« Ce qui se conçoit bien s'énonce clairement » – Boileau",
+    audioUrl: beepAudio,
+    pdfFR: '/methode-4d-fr.pdf',
+    pdfEN: '/methode-4d-en.pdf'
+  },
+  {
+    slug: 'premier-article',
+    title: 'Bienvenue sur mon blog',
+    date: '2025-07-13',
+    excerpt: 'Ceci est le premier article de mon blog.',
+    contentFR:
+      'Ceci est le premier article de mon blog. Il contient un court extrait audio pour accompagner la lecture.',
+    contentEN:
+      'This is the first article of my blog. It contains a short audio snippet to accompany the reading.',
+    quote: 'Knowledge is power',
+    audioUrl: beepAudio,
+    pdfFR: '/premier-article-fr.pdf',
+    pdfEN: '/premier-article-en.pdf'
   }
 ];
+
+export const getArticleBySlug = (slug: string) =>
+  blogArticles.find((a) => a.slug === slug);

--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -1,0 +1,68 @@
+import { useParams, Link } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import { getArticleBySlug } from '@/data/blogData';
+import AudioPlayer from '@/components/blog/AudioPlayer';
+
+const item = {
+  hidden: { opacity: 0, y: 20 },
+  show: { opacity: 1, y: 0 }
+};
+
+const ArticlePage: React.FC = () => {
+  const { slug } = useParams<{ slug: string }>();
+  const article = slug ? getArticleBySlug(slug) : undefined;
+  if (!article) return null;
+
+  return (
+    <section className="min-h-screen py-20 px-6 bg-light dark:bg-dark text-black dark:text-white">
+      <motion.div
+        initial="hidden"
+        animate="show"
+        variants={{ hidden: {}, show: { transition: { staggerChildren: 0.1 } } }}
+        className="max-w-3xl mx-auto space-y-6"
+      >
+        <motion.h1 variants={item} className="text-3xl font-bold">
+          {article.title}
+        </motion.h1>
+        <motion.p variants={item} className="text-sm text-gray-500">
+          {article.date}
+        </motion.p>
+        <motion.blockquote variants={item} className="border-l-4 border-blue-500 pl-4 italic">
+          {article.quote}
+        </motion.blockquote>
+        {article.audioUrl && (
+          <motion.div variants={item}>
+            <AudioPlayer src={article.audioUrl} />
+          </motion.div>
+        )}
+        <motion.div variants={item} className="flex gap-4">
+          <a
+            href={article.pdfFR}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="bg-blue-500 text-white px-4 py-2 rounded-md"
+          >
+            PDF FR
+          </a>
+          <a
+            href={article.pdfEN}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="bg-blue-500 text-white px-4 py-2 rounded-md"
+          >
+            PDF EN
+          </a>
+        </motion.div>
+        <motion.p variants={item}>{article.contentFR}</motion.p>
+        <motion.p variants={item}>{article.contentEN}</motion.p>
+        <motion.div variants={item} whileHover={{ x: -4 }}>
+          <Link to="/blog" className="text-blue-400 hover:underline">
+            ← Back to blog
+          </Link>
+        </motion.div>
+      </motion.div>
+    </section>
+  );
+};
+
+export default ArticlePage;

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import BlogCard from '@/components/blog/BlogCard';
+import { blogArticles } from '@/data/blogData';
+
+const container = {
+  hidden: { opacity: 0 },
+  show: {
+    opacity: 1,
+    transition: { staggerChildren: 0.1 }
+  }
+};
+
+const item = {
+  hidden: { opacity: 0, y: 20 },
+  show: { opacity: 1, y: 0 }
+};
+
+const BlogIndex: React.FC = () => (
+  <section className="min-h-screen py-20 px-6 bg-light dark:bg-dark text-black dark:text-white">
+    <motion.div
+      variants={container}
+      initial="hidden"
+      animate="show"
+      className="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"
+    >
+      {blogArticles.map((article) => (
+        <motion.div key={article.slug} variants={item}>
+          <BlogCard article={article} />
+        </motion.div>
+      ))}
+    </motion.div>
+  </section>
+);
+
+export default BlogIndex;


### PR DESCRIPTION
## Summary
- implement `BlogCard` and `AudioPlayer` in `src/components/blog`
- create typed article data with two sample posts
- build `/blog` page rendering cards in an animated grid
- build dynamic `/blog/[slug]` page showing article details with quote, audio and PDF links

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_b_68747bdfe8908331beb6f66c4b10f913