### PR TITLE
Add scroll-to-top hook

### DIFF
--- a/src/components/ArticlePage.tsx
+++ b/src/components/ArticlePage.tsx
@@ -6,8 +6,10 @@ import { containerVariants, itemVariants } from '../animationVariants';
 import { blogPosts } from '../data/blogData';
 import AudioPlayer from './AudioPlayer';
 import DownloadPDFButtons from './DownloadPDFButtons';
+import useScrollToTop from '../hooks/useScrollToTop';
 
 const ArticlePage = () => {
+  useScrollToTop();
   const { slug } = useParams();
   const { t } = useTranslation();
   const post = blogPosts.find((p) => p.slug === slug);

--- a/src/components/BlogPage.tsx
+++ b/src/components/BlogPage.tsx
@@ -1,10 +1,12 @@
 import { articles } from '../data/articles';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
 import BlogLayout from './BlogLayout';
 import BlogCard from './BlogCard';
-import { Link } from 'react-router-dom';
+import useScrollToTop from '../hooks/useScrollToTop';
 
 const BlogPage = () => {
+  useScrollToTop();
   const { t } = useTranslation();
 
   return (

--- a/src/hooks/useScrollToTop.ts
+++ b/src/hooks/useScrollToTop.ts
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+/**
+ * Scrolls window to the top whenever the location changes.
+ */
+const useScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+};
+
+export default useScrollToTop;


### PR DESCRIPTION
## Summary
- create `useScrollToTop` hook
- scroll to top when navigating blog pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68747be137748331a8119c47c24c5332