### PR TITLE
Add Helmet SEO and accessibility improvements

### DIFF
--- a/src/components/ArticlePage.tsx
+++ b/src/components/ArticlePage.tsx
@@ -6,6 +6,7 @@ import { containerVariants, itemVariants } from '../animationVariants';
 import { blogPosts } from '../data/blogData';
 import AudioPlayer from './AudioPlayer';
 import DownloadPDFButtons from './DownloadPDFButtons';
+import { Helmet } from 'react-helmet';
 
 const ArticlePage = () => {
   const { slug } = useParams();
@@ -14,8 +15,14 @@ const ArticlePage = () => {
 
   if (!post) return null;
 
+  const description = post.sections[0]?.text;
+
   return (
-    <BlogLayout title={post.title} description={post.sections[0]?.text}>
+    <BlogLayout>
+      <Helmet>
+        <title>{post.title}</title>
+        {description && <meta name="description" content={description} />}
+      </Helmet>
       <motion.div
         variants={containerVariants}
         initial="hidden"
@@ -30,7 +37,11 @@ const ArticlePage = () => {
         </motion.p>
         {post.audioUrl && (
           <motion.div variants={itemVariants}>
-            <AudioPlayer src={post.audioUrl} />
+            <AudioPlayer
+              src={post.audioUrl}
+              aria-label="Article audio"
+              className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
+            />
           </motion.div>
         )}
         {post.pdfLinks && (
@@ -46,7 +57,11 @@ const ArticlePage = () => {
             <p>{section.text}</p>
           </motion.div>
         ))}
-        <Link to="/blog" className="text-blue-400 hover:underline block mt-8">
+        <Link
+          to="/blog"
+          aria-label={t('blog.back')}
+          className="text-blue-400 hover:underline block mt-8 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
+        >
           ← {t('blog.back')}
         </Link>
       </motion.div>

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -5,7 +5,12 @@ export interface AudioPlayerProps extends React.AudioHTMLAttributes<HTMLAudioEle
 }
 
 const AudioPlayer: React.FC<AudioPlayerProps> = ({ src, ...props }) => (
-  <audio controls className="w-full" {...props}>
+  <audio
+    controls
+    className="w-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
+    aria-label="Audio player"
+    {...props}
+  >
     <source src={src} type="audio/mpeg" />
     Your browser does not support the audio element.
   </audio>

--- a/src/components/BlogLayout.tsx
+++ b/src/components/BlogLayout.tsx
@@ -1,22 +1,13 @@
 import { ReactNode } from 'react';
-import { Helmet } from 'react-helmet';
 
 interface BlogLayoutProps {
-  title: string;
-  description?: string;
   children: ReactNode;
 }
 
-const BlogLayout = ({ title, description, children }: BlogLayoutProps) => (
-  <>
-    <Helmet>
-      <title>{title}</title>
-      {description && <meta name="description" content={description} />}
-    </Helmet>
-    <section className="min-h-screen py-20 bg-light dark:bg-dark text-black dark:text-white px-6 md:px-10">
-      <div className="max-w-3xl mx-auto space-y-6">{children}</div>
-    </section>
-  </>
+const BlogLayout = ({ children }: BlogLayoutProps) => (
+  <section className="min-h-screen py-20 bg-light dark:bg-dark text-black dark:text-white px-6 md:px-10">
+    <div className="max-w-3xl mx-auto space-y-6">{children}</div>
+  </section>
 );
 
 export default BlogLayout;

--- a/src/components/BlogPage.tsx
+++ b/src/components/BlogPage.tsx
@@ -3,12 +3,16 @@ import { useTranslation } from 'react-i18next';
 import BlogLayout from './BlogLayout';
 import BlogCard from './BlogCard';
 import { Link } from 'react-router-dom';
+import { Helmet } from 'react-helmet';
 
 const BlogPage = () => {
   const { t } = useTranslation();
 
   return (
-    <BlogLayout title={t('blog.title')}>
+    <BlogLayout>
+      <Helmet>
+        <title>{t('blog.title')}</title>
+      </Helmet>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
         {articles.map((article) => (
           <BlogCard key={article.id} article={article} />

--- a/src/components/DownloadPDFButtons.tsx
+++ b/src/components/DownloadPDFButtons.tsx
@@ -12,7 +12,8 @@ const DownloadPDFButtons: React.FC<DownloadPDFButtonsProps> = ({ pdfLinks }) => 
         href={url}
         target="_blank"
         rel="noopener noreferrer"
-        className="bg-blue-500 text-white px-4 py-2 rounded-md"
+        aria-label={`Download PDF ${lang.toUpperCase()}`}
+        className="bg-blue-500 text-white px-4 py-2 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
       >
         PDF {lang.toUpperCase()}
       </a>

--- a/src/pages/blog/[slug]/pdf.tsx
+++ b/src/pages/blog/[slug]/pdf.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
+import { Helmet } from 'react-helmet';
 import { blogPosts } from '../../../data/blogData';
 
 const PrintArticle: React.FC = () => {
@@ -10,6 +11,9 @@ const PrintArticle: React.FC = () => {
 
   return (
     <div className="p-6 space-y-4">
+      <Helmet>
+        <title>{post.title}</title>
+      </Helmet>
       <h1 className="text-3xl font-bold">{post.title}</h1>
       {post.sections.map((section, idx) => (
         <div key={idx} className="space-y-2">
@@ -19,7 +23,8 @@ const PrintArticle: React.FC = () => {
       ))}
       <button
         onClick={() => window.print()}
-        className="bg-blue-500 text-white px-4 py-2 rounded-md mt-4"
+        aria-label="Print article"
+        className="bg-blue-500 text-white px-4 py-2 rounded-md mt-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
       >
         Print
       </button>


### PR DESCRIPTION
## Summary
- update BlogLayout to remove Helmet logic
- use Helmet in BlogPage, ArticlePage and PDF page
- add ARIA labels and focus-visible classes
- enhance audio player accessibility

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68747be50fcc8331a3de66d5834618ec