### PR TITLE
Add CSS-based starry background

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,4 @@
 import React, { Suspense, useEffect } from "react";
-import { Canvas } from "@react-three/fiber";
-import { Stars } from "@react-three/drei";
 import Header from "./components/Header";
 import Hero from "./components/Hero";
 import About from "./components/About";
@@ -12,6 +10,7 @@ import Footer from "./components/Footer";
 import CursorEffect from "./components/CursorEffect";
 import FloatingAgentIA from "./components/FloatingAgentIA";
 import ScrollToHash from "./components/ScrollToHash";
+import GlobalBackground from "./components/GlobalBackground";
 import { Routes, Route } from "react-router-dom";
 import i18n from "./i18n";
 
@@ -67,11 +66,7 @@ function App() {
 
   return (
     <div>
-      <div className="fixed top-0 left-0 w-full h-full -z-10 pointer-events-none">
-        <Canvas camera={{ position: [0, 0, 1] }}>
-          <Stars radius={100} depth={80} count={3000} factor={4} fade />
-        </Canvas>
-      </div>
+      <GlobalBackground />
       <CursorEffect />
       <ScrollToHash />
       <Header />

--- a/src/components/GlobalBackground.tsx
+++ b/src/components/GlobalBackground.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const GlobalBackground: React.FC = () => {
+  return (
+    <div className="stars fixed inset-0 w-full h-full -z-10 pointer-events-none dark:block hidden" />
+  );
+};
+
+export default GlobalBackground;

--- a/src/index.css
+++ b/src/index.css
@@ -209,3 +209,46 @@ html.dark {
   transform: rotateX(-90deg) translateZ(60px);
 }
 
+
+/* Global galactic background for dark mode */
+.stars {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: -10;
+}
+
+.stars::before,
+.stars::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-repeat: repeat;
+  background-position: 0 0;
+}
+
+.stars::before {
+  background-image: radial-gradient(#ffffff 1px, transparent 1px);
+  background-size: 2px 2px;
+  opacity: 0.4;
+  animation: move-stars 100s linear infinite;
+}
+
+.stars::after {
+  background-image: radial-gradient(#ffffff 1.5px, transparent 1.5px);
+  background-size: 3px 3px;
+  opacity: 0.2;
+  animation: move-stars 160s linear infinite;
+}
+
+@keyframes move-stars {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(-1000px);
+  }
+}


### PR DESCRIPTION
## Summary
- implement `GlobalBackground` component
- add CSS for starfield animation
- show the background in `App` for dark mode only

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_b_6877306334b883319ff3b658a4995d8a