### PR TITLE
Add lazy loading to images

### DIFF
--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -32,6 +32,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
       <img
         src={image}
         alt={title}
+        loading="lazy"
         className="w-full h-48 object-cover rounded-t-lg transition-transform duration-500 ease-out group-hover:scale-105"
       />
     </div>


### PR DESCRIPTION
## Summary
- add `loading="lazy"` to ProjectCard images for better performance

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6879b26c2ba8833193dfc2d36c3d179e