### PR TITLE
Add sitemap generation and robots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.3.0",
         "vite": "^5.4.19",
+        "vite-plugin-sitemap": "^0.8.2",
         "vitest": "^1.4.0"
       }
     },
@@ -8220,6 +8221,12 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/vite-plugin-sitemap": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-sitemap/-/vite-plugin-sitemap-0.8.2.tgz",
+      "integrity": "sha512-bqIw6NVOXg6je81lzX8Lm0vjf8/QSAp8di8fYQzZ3ZdVicOm8+6idBGALJiy1R1FiXNIK8rgORO6HBqXyHW+iQ==",
+      "dev": true
     },
     "node_modules/vitest": {
       "version": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
     "vite": "^5.4.19",
+    "vite-plugin-sitemap": "^0.8.2",
     "vitest": "^1.4.0"
   }
 }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://karimhammouche.com/sitemap.xml

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,18 @@
 import { defineConfig } from 'vite';
 import { resolve } from 'path';
 import react from '@vitejs/plugin-react';
+import Sitemap from 'vite-plugin-sitemap';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    Sitemap({
+      hostname: 'https://karimhammouche.com',
+      dynamicRoutes: ['/test-supabase'],
+      generateRobotsTxt: false,
+    }),
+  ],
   optimizeDeps: {
     exclude: ['lucide-react'],
   },


### PR DESCRIPTION
## Summary
- generate sitemap during `npm run build` using `vite-plugin-sitemap`
- configure plugin with hostname and dynamic routes
- add a default `robots.txt` allowing all crawlers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6879c56aa4f48331889f878a26b99506