### PR TITLE
Fix SEO component conflict

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import Footer from "./components/Footer";
 import CursorEffect from "./components/CursorEffect";
 import FloatingAgentIA from "./components/FloatingAgentIA";
 import ScrollToHash from "./components/ScrollToHash";
-import SEO from "./components/SEO";
+import StructuredSEO from "./components/StructuredSEO";
 import { Routes, Route } from "react-router-dom";
 import TestFormSupabase from "./components/TestFormSupabase";
 import i18n from "./i18n";
@@ -33,7 +33,10 @@ const initGA = (id: string) => {
 
 const HomePage = () => (
   <main>
-    <SEO titleKey="seo.home.title" descriptionKey="seo.home.description" />
+    <>
+      <SEO titleKey="seo.home.title" descriptionKey="seo.home.description" />
+      <StructuredSEO />
+    </>
     <Hero />
     <About />
     <Skills />
@@ -70,7 +73,10 @@ function App() {
   return (
     <div>
       <CursorEffect />
-      <SEO />
+      <>
+        <SEO />
+        <StructuredSEO />
+      </>
       <ScrollToHash />
       <Header />
       <Suspense fallback={<div>Loading...</div>}>

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { Helmet } from 'react-helmet'
 import { useTranslation } from 'react-i18next'
 import { useLocation } from 'react-router-dom'
-import { projects } from '../data/projects'
 
 interface SEOProps {
   titleKey?: string
@@ -33,30 +32,6 @@ const SEO: React.FC<SEOProps> = ({
   const title = titleKey ? t(titleKey) : 'Karim Hammouche – Portfolio'
   const description = descriptionKey ? t(descriptionKey) : 'Portfolio de Karim Hammouche, développeur créatif et entrepreneur.'
 
-  // JSON-LD : données structurées Schema.org
-  const websiteData = {
-    '@context': 'https://schema.org',
-    '@type': 'WebSite',
-    url: SITE_URL,
-    name: 'Karim Hammouche | Portfolio',
-    inLanguage: lang,
-  }
-
-  const personData = {
-    '@context': 'https://schema.org',
-    '@type': 'Person',
-    name: 'Karim Hammouche',
-    url: SITE_URL,
-  }
-
-  const projectData = projects.map((p) => ({
-    '@context': 'https://schema.org',
-    '@type': 'CreativeWork',
-    name: p.title[lang],
-    description: p.description[lang],
-    image: p.image,
-    ...(p.url ? { url: p.url } : {}),
-  }))
 
   return (
     <Helmet>
@@ -79,14 +54,6 @@ const SEO: React.FC<SEOProps> = ({
       {/* Langue et direction (RTL si arabe) */}
       <html lang={i18n.language} dir={i18n.language === 'ar' ? 'rtl' : 'ltr'} />
 
-      {/* Données structurées (JSON-LD) */}
-      <script type="application/ld+json">{JSON.stringify(websiteData)}</script>
-      <script type="application/ld+json">{JSON.stringify(personData)}</script>
-      {projectData.map((data, idx) => (
-        <script key={projects[idx].id} type="application/ld+json">
-          {JSON.stringify(data)}
-        </script>
-      ))}
     </Helmet>
   )
 }

--- a/src/components/StructuredSEO.tsx
+++ b/src/components/StructuredSEO.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import { Helmet } from 'react-helmet'
+import { useTranslation } from 'react-i18next'
+import { projects } from '../data/projects'
+
+const SITE_URL = 'https://karimhammouche.com'
+
+const StructuredSEO: React.FC = () => {
+  const { i18n } = useTranslation()
+  const lang = (i18n.language as 'fr' | 'en') || 'fr'
+
+  const websiteData = {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    url: SITE_URL,
+    name: 'Karim Hammouche | Portfolio',
+    inLanguage: lang,
+  }
+
+  const personData = {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name: 'Karim Hammouche',
+    url: SITE_URL,
+  }
+
+  const projectData = projects.map((p) => ({
+    '@context': 'https://schema.org',
+    '@type': 'CreativeWork',
+    name: p.title[lang],
+    description: p.description[lang],
+    image: p.image,
+    ...(p.url ? { url: p.url } : {}),
+  }))
+
+  return (
+    <Helmet>
+      <script type="application/ld+json">{JSON.stringify(websiteData)}</script>
+      <script type="application/ld+json">{JSON.stringify(personData)}</script>
+      {projectData.map((data, idx) => (
+        <script key={projects[idx].id} type="application/ld+json">
+          {JSON.stringify(data)}
+        </script>
+      ))}
+    </Helmet>
+  )
+}
+
+export default StructuredSEO


### PR DESCRIPTION
## Summary
- separate JSON-LD logic into new `StructuredSEO` component
- keep classic SEO tags inside `SEO`
- use both SEO components in `App`

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_b_6879cd75c1008331a9b3148d7f292778