### PR TITLE
Add TravelMap page with Three.js canvas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@emailjs/browser": "^4.4.1",
         "@react-three/drei": "^9.122.0",
         "@react-three/fiber": "^8.18.0",
+        "@react-three/rapier": "^1.5.0",
         "@supabase/supabase-js": "^2.52.0",
         "@types/react-helmet": "^6.1.11",
         "dompurify": "^3.2.6",
@@ -29,7 +30,8 @@
         "react-vertical-timeline-component": "^3.6.0",
         "three": "^0.162.0",
         "typewriter-effect": "^2.21.0",
-        "zod": "^3.22.4"
+        "zod": "^3.22.4",
+        "zustand": "^5.0.6"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.1",
@@ -509,6 +511,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.14.0.tgz",
+      "integrity": "sha512-/uHrUzS+CRQ+NQrrJCEDUkhwHlNsAAexbNXgbN9sHY+GwR+SFFAFrxRr8Llf5/AJZzqiLANdQIfJ63Cw4gJVqw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@emailjs/browser": {
       "version": "4.4.1",
@@ -1445,6 +1453,21 @@
         "react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-three/rapier": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@react-three/rapier/-/rapier-1.5.0.tgz",
+      "integrity": "sha512-gylk2KyCer9EoymFyTyc+g2IqyAq4mTbZgaHoSJi6gHoXlJsC2LVeN4jedvegvjUsXPExdE60wHjCPa+DS4iXw==",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "0.14.0",
+        "suspend-react": "^0.1.3",
+        "three-stdlib": "^2.29.4"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": ">=8.9.0",
+        "react": ">=18.0.0",
+        "three": ">=0.139.0"
       }
     },
     "node_modules/@remix-run/router": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@emailjs/browser": "^4.4.1",
     "@react-three/drei": "^9.122.0",
     "@react-three/fiber": "^8.18.0",
+    "@react-three/rapier": "^1.5.0",
     "@supabase/supabase-js": "^2.52.0",
     "@types/react-helmet": "^6.1.11",
     "dompurify": "^3.2.6",
@@ -33,7 +34,8 @@
     "react-vertical-timeline-component": "^3.6.0",
     "three": "^0.162.0",
     "typewriter-effect": "^2.21.0",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "zustand": "^5.0.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import ScrollToHash from "./components/ScrollToHash";
 import StructuredSEO from "./components/StructuredSEO";
 import { Routes, Route } from "react-router-dom";
 import TestFormSupabase from "./components/TestFormSupabase";
+import TravelMap from "./pages/TravelMap";
 import i18n from "./i18n";
 
 // 📈 Fonction pour initialiser Google Analytics
@@ -83,6 +84,7 @@ function App() {
         <Routes>
           <Route path="/" element={<HomePage />} />
           <Route path="/test-supabase" element={<TestFormSupabase />} />
+          <Route path="/travel-map" element={<TravelMap />} />
         </Routes>
       </Suspense>
       <Footer />

--- a/src/components/CountryInfo.tsx
+++ b/src/components/CountryInfo.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface CountryInfoProps {
+  country: string | null;
+}
+
+const CountryInfo: React.FC<CountryInfoProps> = ({ country }) => {
+  if (!country) return null;
+
+  return (
+    <div className="absolute top-4 left-4 bg-white dark:bg-darker p-4 shadow">
+      <p className="text-sm">Selected: {country}</p>
+    </div>
+  );
+};
+
+export default CountryInfo;

--- a/src/components/CountryModal.tsx
+++ b/src/components/CountryModal.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+interface CountryModalProps {
+  country: string | null;
+  onClose: () => void;
+}
+
+const CountryModal: React.FC<CountryModalProps> = ({ country, onClose }) => {
+  if (!country) return null;
+
+  return (
+    <div className="absolute inset-0 flex items-center justify-center bg-black/50">
+      <div className="bg-white dark:bg-darker p-6 rounded">
+        <p className="mb-4 text-center">Information about {country}</p>
+        <button
+          onClick={onClose}
+          className="px-4 py-2 bg-gray-800 text-white rounded"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default CountryModal;

--- a/src/components/MinecraftWorld.tsx
+++ b/src/components/MinecraftWorld.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { RigidBody } from '@react-three/rapier';
+
+import { generateTerrain } from '../utils/terrainGenerator';
+import { loadBlockTexture } from '../utils/textureGenerator';
+
+interface MinecraftWorldProps {
+  onSelectCountry?: (country: string) => void;
+}
+
+const MinecraftWorld: React.FC<MinecraftWorldProps> = ({ onSelectCountry }) => {
+  // Example terrain blocks
+  const blocks = generateTerrain(10, 10);
+  const texture = loadBlockTexture();
+
+  return (
+    <group>
+      {blocks.map((pos, idx) => (
+        <RigidBody key={idx} type="fixed" colliders="cuboid">
+          <mesh
+            position={pos}
+            onClick={() => onSelectCountry && onSelectCountry('Morocco')}
+          >
+            <boxGeometry args={[1, 1, 1]} />
+            <meshStandardMaterial map={texture} />
+          </mesh>
+        </RigidBody>
+      ))}
+    </group>
+  );
+};
+
+export default MinecraftWorld;

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -23,7 +23,6 @@ const SEO: React.FC<SEOProps> = ({
   const { t, i18n } = useTranslation()
   const { pathname } = useLocation()
 
-  const lang = (i18n.language as 'fr' | 'en') || 'fr'
   const baseUrl = url || `${SITE_URL}${pathname}`
   const canonicalUrl = canonical || baseUrl
   const frUrl = `${baseUrl}?lang=fr`

--- a/src/pages/TravelMap.tsx
+++ b/src/pages/TravelMap.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls } from '@react-three/drei';
+import { Physics } from '@react-three/rapier';
+import MinecraftWorld from '../components/MinecraftWorld';
+import CountryModal from '../components/CountryModal';
+import CountryInfo from '../components/CountryInfo';
+
+const TravelMap: React.FC = () => {
+  const [selectedCountry, setSelectedCountry] = useState<string | null>(null);
+
+  return (
+    <div className="w-full h-screen">
+      <Canvas camera={{ position: [5, 5, 5] }}>
+        <ambientLight intensity={0.5} />
+        <Physics gravity={[0, -9.81, 0]}>
+          <MinecraftWorld onSelectCountry={setSelectedCountry} />
+        </Physics>
+        <OrbitControls />
+      </Canvas>
+      <CountryInfo country={selectedCountry} />
+      <CountryModal
+        country={selectedCountry}
+        onClose={() => setSelectedCountry(null)}
+      />
+    </div>
+  );
+};
+
+export default TravelMap;

--- a/src/utils/playerStore.ts
+++ b/src/utils/playerStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface PlayerState {
+  position: [number, number, number];
+  setPosition: (pos: [number, number, number]) => void;
+}
+
+export const usePlayerStore = create<PlayerState>(set => ({
+  position: [0, 1, 0],
+  setPosition: pos => set({ position: pos }),
+}));

--- a/src/utils/terrainGenerator.ts
+++ b/src/utils/terrainGenerator.ts
@@ -1,0 +1,9 @@
+export const generateTerrain = (width: number, depth: number) => {
+  const blocks: [number, number, number][] = [];
+  for (let x = 0; x < width; x++) {
+    for (let z = 0; z < depth; z++) {
+      blocks.push([x, 0, z]);
+    }
+  }
+  return blocks;
+};

--- a/src/utils/textureGenerator.ts
+++ b/src/utils/textureGenerator.ts
@@ -1,0 +1,15 @@
+import * as THREE from "three";
+import { TextureLoader } from 'three';
+
+let cachedTexture: THREE.Texture | null = null;
+
+export const loadBlockTexture = () => {
+  if (cachedTexture) return cachedTexture;
+  const loader = new TextureLoader();
+  cachedTexture = loader.load(
+    'https://cdn.jsdelivr.net/gh/pmndrs/drei-assets@master/grass.jpg'
+  );
+  cachedTexture.magFilter = THREE.NearestFilter;
+  cachedTexture.minFilter = THREE.NearestFilter;
+  return cachedTexture;
+};

--- a/tests/translation.test.ts
+++ b/tests/translation.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { translateText, LIBRETRANSLATE_URL } from '../src/utils/translation';
 
 describe('translateText', () => {


### PR DESCRIPTION
## Summary
- add react-three-rapier and zustand dependencies
- add `TravelMap` page with a Three.js canvas
- create `MinecraftWorld`, `CountryInfo` and `CountryModal` components
- include utilities for generating terrain, textures and player store
- wire new page into the router
- fix lint issues

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687cdd22a59c8331b2365a148c54420b