### PR TITLE
Add country audio modal

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+
+interface AudioPlayerProps {
+  src: string
+}
+
+export default function AudioPlayer({ src }: AudioPlayerProps) {
+  if (!src) return null
+
+  return (
+    <audio
+      controls
+      className="w-full mt-4 rounded text-white bg-zinc-800"
+    >
+      <source src={src} />
+      Your browser does not support the audio element.
+    </audio>
+  )
+}

--- a/src/components/CountryModal.tsx
+++ b/src/components/CountryModal.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react'
+import { getCountryAudio } from '../lib/supabaseClient'
+import AudioPlayer from './AudioPlayer'
+
+interface CountryModalProps {
+  slug: string
+  onClose: () => void
+}
+
+export default function CountryModal({ slug, onClose }: CountryModalProps) {
+  const [audioUrl, setAudioUrl] = useState<string | null>(null)
+  const [language, setLanguage] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    async function load() {
+      try {
+        setLoading(true)
+        const data = await getCountryAudio(slug)
+        setAudioUrl(data?.url || null)
+        setLanguage(data?.language || null)
+      } catch (err) {
+        console.error(err)
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [slug])
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70">
+      <div className="relative w-full max-w-md rounded-lg bg-zinc-900 p-6 text-white">
+        <button
+          onClick={onClose}
+          className="absolute right-3 top-3 text-gray-400 hover:text-white"
+          aria-label="Close"
+        >
+          &times;
+        </button>
+        <h2 className="mb-4 text-xl font-semibold capitalize">{slug}</h2>
+        {loading && <p>Loading...</p>}
+        {!loading && audioUrl && (
+          <>
+            {language && <p className="text-sm text-gray-400">{language}</p>}
+            <AudioPlayer src={audioUrl} />
+          </>
+        )}
+        {!loading && !audioUrl && <p className="text-gray-400">No audio available.</p>}
+      </div>
+    </div>
+  )
+}

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,6 +1,53 @@
 import { createClient } from "@supabase/supabase-js"
 
+export interface CountryAudioRow {
+  id: number
+  slug: string
+  url: string
+  language: string
+}
+
+export interface CountryAudioInsert {
+  slug: string
+  url: string
+  language: string
+}
+
+export interface Database {
+  public: {
+    Tables: {
+      country_audio: {
+        Row: CountryAudioRow
+        Insert: CountryAudioInsert
+        Update: Partial<CountryAudioInsert>
+      }
+    }
+  }
+}
+
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL!
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY!
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey)
+export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey)
+
+export async function getCountryAudio(slug: string) {
+  const { data, error } = await supabase
+    .from('country_audio')
+    .select('*')
+    .eq('slug', slug)
+    .maybeSingle()
+
+  if (error) throw error
+  return data
+}
+
+export async function insertCountryAudio(entry: CountryAudioInsert) {
+  const { data, error } = await supabase
+    .from('country_audio')
+    .insert(entry)
+    .select()
+    .single()
+
+  if (error) throw error
+  return data
+}


### PR DESCRIPTION
## Summary
- expand `supabaseClient` with `country_audio` table types and helpers
- add dark-themed `AudioPlayer` component
- implement `CountryModal` that fetches and plays audio using the new helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687cdd23cfc8833181ecf303eea4e3a5