### PR TITLE
Add blog translation keys

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,5 +1,13 @@
 {
-  ...
+  "nav": {
+    "home": "Home",
+    "about": "About",
+    "skills": "Skills",
+    "projects": "Projects",
+    "experience": "Experience",
+    "contact": "Contact",
+    "blog": "Blog"
+  },
   "countries": {
     "title": "Countries",
     "france": "Known for its gastronomy and rich cultural heritage.",
@@ -20,5 +28,10 @@
     "searchPlaceholder": "Search a country...",
     "noResults": "No countries found."
   },
-  ...
+  "blog": {
+    "title": "Blog",
+    "readArticle": "Read Article",
+    "downloadPDF": "Download PDF",
+    "listenAudio": "Listen Audio"
+  }
 }

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -1,5 +1,13 @@
 {
-  ...
+  "nav": {
+    "home": "Accueil",
+    "about": "À propos",
+    "skills": "Compétences",
+    "projects": "Projets",
+    "experience": "Expérience",
+    "contact": "Contact",
+    "blog": "Blog"
+  },
   "countries": {
     "title": "Pays",
     "france": "Réputée pour sa gastronomie et sa richesse culturelle.",
@@ -20,5 +28,10 @@
     "searchPlaceholder": "Recherchez un pays...",
     "noResults": "Aucun pays trouvé."
   },
-  ...
+  "blog": {
+    "title": "Blog",
+    "readArticle": "Lire l'article",
+    "downloadPDF": "Télécharger le PDF",
+    "listenAudio": "Écouter l'audio"
+  }
 }

--- a/tests/blogKeys.test.ts
+++ b/tests/blogKeys.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import i18n from '../src/i18n';
+
+describe('blog translation keys', () => {
+  it('loads blog section and navigation labels', () => {
+    const enTitle = i18n.t('blog.title', { lng: 'en' });
+    const frTitle = i18n.t('blog.title', { lng: 'fr' });
+    expect(enTitle).not.toBe('blog.title');
+    expect(frTitle).not.toBe('blog.title');
+
+    const enNav = i18n.t('nav.blog', { lng: 'en' });
+    const frNav = i18n.t('nav.blog', { lng: 'fr' });
+    expect(enNav).not.toBe('nav.blog');
+    expect(frNav).not.toBe('nav.blog');
+  });
+});


### PR DESCRIPTION
## Summary
- add Blog section strings in French and English JSON files
- expose navigation label for Blog
- verify new keys with unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687ce42dd1308331b5976a7d77ba5d82