### PR TITLE
Update three to 0.178.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "react-markdown": "^10.1.0",
         "react-router-dom": "^6.30.1",
         "react-vertical-timeline-component": "^3.6.0",
-        "three": "^0.154.0",
+        "three": "^0.178.0",
         "typewriter-effect": "^2.21.0",
         "zod": "^3.22.4",
         "zustand": "^5.0.6"
@@ -42,7 +42,7 @@
         "@types/react-dom": "^18.3.0",
         "@types/react-router-dom": "^5.3.3",
         "@types/react-vertical-timeline-component": "^3.3.6",
-        "@types/three": "^0.162.0",
+        "@types/three": "^0.178.1",
         "@vitejs/plugin-react": "^4.3.1",
         "autoprefixer": "^10.4.18",
         "eslint": "^9.30.1",
@@ -2177,17 +2177,31 @@
       "license": "MIT"
     },
     "node_modules/@types/three": {
-      "version": "0.162.0",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.162.0.tgz",
-      "integrity": "sha512-0j5yZcVukVIhrhSIC7+LmBPkkMoMuEJ1AfYBZfgNytdYqYREMuiyXWhYOMeZLBElTEAlJIZn7r2W3vqTIgjWlg==",
+      "version": "0.178.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.178.1.tgz",
+      "integrity": "sha512-WSabew1mgWgRx2RfLfKY+9h4wyg6U94JfLbZEGU245j/WY2kXqU0MUfghS+3AYMV5ET1VlILAgpy77cB6a3Itw==",
       "license": "MIT",
       "dependencies": {
-        "@tweenjs/tween.js": "~23.1.1",
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
         "@types/stats.js": "*",
         "@types/webxr": "*",
-        "fflate": "~0.6.10",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
         "meshoptimizer": "~0.18.1"
       }
+    },
+    "node_modules/@types/three/node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@types/three/node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -2635,6 +2649,12 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.64",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.64.tgz",
+      "integrity": "sha512-84kRIAGV46LJTlJZWxShiOrNL30A+9KokD7RB3dRCIqODFjodS5tCD5yyiZ8kIReGVZSDfA3XkkwyyOIF6K62A==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/accessor-fn": {
       "version": "1.5.3",
@@ -5069,12 +5089,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/globe.gl/node_modules/three": {
-      "version": "0.178.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.178.0.tgz",
-      "integrity": "sha512-ybFIB0+x8mz0wnZgSGy2MO/WCO6xZhQSZnmfytSPyNpM0sBafGRVhdaj+erYh5U+RhQOAg/eXqw5uVDiM2BjhQ==",
-      "license": "MIT"
     },
     "node_modules/globe.gl/node_modules/three-render-objects": {
       "version": "1.40.4",
@@ -9368,9 +9382,9 @@
       }
     },
     "node_modules/three": {
-      "version": "0.154.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.154.0.tgz",
-      "integrity": "sha512-Uzz8C/5GesJzv8i+Y2prEMYUwodwZySPcNhuJUdsVMH2Yn4Nm8qlbQe6qRN5fOhg55XB0WiLfTPBxVHxpE60ug==",
+      "version": "0.178.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.178.0.tgz",
+      "integrity": "sha512-ybFIB0+x8mz0wnZgSGy2MO/WCO6xZhQSZnmfytSPyNpM0sBafGRVhdaj+erYh5U+RhQOAg/eXqw5uVDiM2BjhQ==",
       "license": "MIT"
     },
     "node_modules/three-conic-polygon-geometry": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "react-markdown": "^10.1.0",
     "react-router-dom": "^6.30.1",
     "react-vertical-timeline-component": "^3.6.0",
-    "three": "^0.154.0",
+    "three": "^0.178.0",
     "typewriter-effect": "^2.21.0",
     "zod": "^3.22.4",
     "zustand": "^5.0.6"
@@ -48,7 +48,7 @@
     "@types/react-dom": "^18.3.0",
     "@types/react-router-dom": "^5.3.3",
     "@types/react-vertical-timeline-component": "^3.3.6",
-    "@types/three": "^0.162.0",
+    "@types/three": "^0.178.1",
     "@vitejs/plugin-react": "^4.3.1",
     "autoprefixer": "^10.4.18",
     "eslint": "^9.30.1",


### PR DESCRIPTION
## Summary
- bump three to 0.178.0 and update @types/three
- reinstall node modules

## Testing
- `npm install`
- `npm list three`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687cf2678e0c833182429d473cc1c17b