### PR TITLE
Add three dependency fix script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "codex:sync": "sh ./codex-sync.sh",
     "test": "vitest run",
     "clean:binaries": "ts-node --project tsconfig.node.json scripts/clean-binaries.ts",
-    "fix:deps": "ts-node scripts/fix-deps.ts"
+    "fix:deps": "ts-node scripts/fix-deps.ts",
+    "fix:three-deps": "ts-node scripts/fix-three-deps.ts"
   },
   "dependencies": {
     "@emailjs/browser": "^4.4.1",

--- a/scripts/fix-three-deps.ts
+++ b/scripts/fix-three-deps.ts
@@ -1,0 +1,32 @@
+import { execSync } from 'child_process';
+import fs from 'fs';
+
+/**
+ * Cleanup and reinstall Three.js dependencies.
+ *
+ * Steps:
+ * 1. Delete `node_modules` and `package-lock.json`.
+ * 2. Reinstall three along with all packages that use it.
+ * 3. Print a success message when done.
+ */
+
+console.log('🧹 Removing node_modules and lockfile...');
+if (fs.existsSync('node_modules')) {
+  fs.rmSync('node_modules', { recursive: true, force: true });
+}
+if (fs.existsSync('package-lock.json')) {
+  fs.rmSync('package-lock.json', { force: true });
+}
+
+console.log('📦 Installing Three.js related packages...');
+const packages = [
+  'three@0.154.0',
+  '@react-three/fiber@8.18.0',
+  '@react-three/drei@9.122.0',
+  '@react-three/rapier@1.5.0',
+  'react-globe.gl@2.34.0',
+  '@types/three@0.162.0'
+];
+execSync(`npm install ${packages.join(' ')}`, { stdio: 'inherit' });
+
+console.log('✅ Three.js dependencies reinstalled successfully.');


### PR DESCRIPTION
## Summary
- add `scripts/fix-three-deps.ts` to wipe node_modules and reinstall Three.js packages
- wire it up with `npm run fix:three-deps`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687cf2689e0c8331b6ac7e8f434ce584