### PR TITLE
Fix Vite optimizeDeps

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,10 +19,12 @@ export default defineConfig({
       'three/examples/jsm/nodes/Nodes.js',
       'three/examples/jsm/AdditiveBlendingShader.js',
       'three/examples/jsm/WebGPURenderer.js',
+    ],
+    exclude: [
+      'lucide-react',
       'three/webgpu',
       'three/tsl',
     ],
-    exclude: ['lucide-react'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- disable three submodules that cause pre-bundling errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687cf78b534c83318ad99ae09a36e03e