### PR TITLE
Update ts-node scripts with esm loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,11 @@
     "preview": "vite preview",
     "codex:sync": "sh ./codex-sync.sh",
     "test": "vitest run",
-    "clean:binaries": "ts-node --project tsconfig.node.json scripts/clean-binaries.ts",
-    "fix:deps": "ts-node scripts/fix-deps.ts",
-    "fix:three-deps": "ts-node scripts/fix-three-deps.ts"
+    "clean:binaries": "ts-node --loader ts-node/esm --project tsconfig.node.json scripts/clean-binaries.ts",
+    "fix:deps": "ts-node --loader ts-node/esm scripts/fix-deps.ts",
+    "fix:three-deps": "ts-node --loader ts-node/esm scripts/fix-three-deps.ts",
+    "fix:three-missing": "ts-node --loader ts-node/esm scripts/fix-three-missing.ts",
+    "fix:three-all": "npm run fix:three-deps && npm run fix:three-missing"
   },
   "dependencies": {
     "@emailjs/browser": "^4.4.1",


### PR DESCRIPTION
## Summary
- use `--loader ts-node/esm` for ts-node scripts
- add `fix:three-missing` and `fix:three-all` npm scripts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687d0172fa908331bf7839ba3f703b8e