### PR TITLE
Add script for updating three imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "vitest run",
     "clean:binaries": "ts-node --project tsconfig.node.json scripts/clean-binaries.ts",
     "fix:deps": "ts-node scripts/fix-deps.ts",
-    "fix:three-deps": "ts-node scripts/fix-three-deps.ts"
+    "fix:three-deps": "ts-node scripts/fix-three-deps.ts",
+    "fix:three-missing": "ts-node scripts/fix-three-missing.ts"
   },
   "dependencies": {
     "@emailjs/browser": "^4.4.1",

--- a/scripts/fix-three-missing.ts
+++ b/scripts/fix-three-missing.ts
@@ -1,0 +1,26 @@
+import fs from 'fs/promises';
+import fg from 'fast-glob';
+
+async function main() {
+  const files = await fg('src/**/*.{ts,tsx}', { absolute: true });
+  let count = 0;
+
+  for (const file of files) {
+    const content = await fs.readFile(file, 'utf8');
+    if (content.includes('three/examples/jsm/')) {
+      const updated = content.replace(/from ['"]three\/examples\/jsm\//g, "from 'three-stdlib/");
+      if (updated !== content) {
+        await fs.writeFile(file, updated);
+        console.log(`Updated ${file}`);
+        count++;
+      }
+    }
+  }
+
+  console.log(`\u2705 Replaced imports in ${count} file${count === 1 ? '' : 's'}.`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `fix-three-missing.ts` utility to migrate missing three.js imports
- expose `fix:three-missing` npm script

## Testing
- `npm test` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_b_687d017478b88331ad9d5177d9ff747b