### PR TITLE
Replace three examples deps

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,9 +16,9 @@ export default defineConfig({
   optimizeDeps: {
     include: [
       'three',
-      'three/examples/jsm/nodes/Nodes.js',
-      'three/examples/jsm/AdditiveBlendingShader.js',
-      'three/examples/jsm/WebGPURenderer.js',
+      'three-stdlib/nodes',
+      'three-stdlib/shaders/AdditiveBlendingShader',
+      'three-stdlib/renderers/webgpu/WebGPURenderer',
     ],
     exclude: [
       'lucide-react',


### PR DESCRIPTION
## Summary
- switch vite optimizeDeps entries from `three/examples/jsm` to `three-stdlib` equivalents

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687d017628448331a0a14cebe91e01ed