### PR TITLE
Remove unused react-router-dom types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,6 @@
         "@eslint/js": "^9.9.1",
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
-        "@types/react-router-dom": "^5.3.3",
         "@types/react-vertical-timeline-component": "^3.3.6",
         "@types/three": "^0.150.2",
         "@vitejs/plugin-react": "^4.3.1",
@@ -2055,13 +2054,6 @@
         "@types/unist": "*"
       }
     },
-    "node_modules/@types/history": {
-      "version": "4.7.11",
-      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
-      "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2147,29 +2139,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/react": "*"
-      }
-    },
-    "node_modules/@types/react-router": {
-      "version": "5.1.20",
-      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.20.tgz",
-      "integrity": "sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*"
-      }
-    },
-    "node_modules/@types/react-router-dom": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
-      "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router": "*"
       }
     },
     "node_modules/@types/react-vertical-timeline-component": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@eslint/js": "^9.9.1",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
-    "@types/react-router-dom": "^5.3.3",
     "@types/react-vertical-timeline-component": "^3.3.6",
     "@types/three": "^0.150.2",
     "@vitejs/plugin-react": "^4.3.1",


### PR DESCRIPTION
## Summary
- remove `@types/react-router-dom` from dev deps
- update lockfile

## Testing
- `npm test`
- `npm run build` *(fails: missing `three/webgpu`)*

------
https://chatgpt.com/codex/tasks/task_b_687d05d790e88331a4fc914ca6719c49