### PR TITLE
Fix README and license name typo

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Porfolio contributors
+Copyright (c) 2024 Portfolio contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Porfolio
+# Portfolio
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- correct heading in `README.md`
- fix `Portfolio contributors` typo in `LICENSE`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687d05d88fa4833187e06f292a15d469