### PR TITLE
Fix structured SEO export

### DIFF
--- a/src/components/StructuredSEO.tsx
+++ b/src/components/StructuredSEO.tsx
@@ -5,10 +5,7 @@ import { projects } from '../data/projects'
 
 const SITE_URL = 'https://karimhammouche.com'
 
-const StructuredSEO: React.FC = () => {
-  const { i18n } = useTranslation()
-  const lang = (i18n.language as 'fr' | 'en') || 'fr'
-
+export const getStructuredData = (lang: 'fr' | 'en') => {
   const websiteData = {
     '@context': 'https://schema.org',
     '@type': 'WebSite',
@@ -28,10 +25,19 @@ const StructuredSEO: React.FC = () => {
     '@context': 'https://schema.org',
     '@type': 'CreativeWork',
     name: p.title[lang],
-    description: p.description[lang],
+    description: p.description[lang].join(' '),
     image: p.image,
     ...(p.url ? { url: p.url } : {}),
   }))
+
+  return { websiteData, personData, projectData }
+}
+
+const StructuredSEO: React.FC = () => {
+  const { i18n } = useTranslation()
+  const lang = (i18n.language as 'fr' | 'en') || 'fr'
+
+  const { websiteData, personData, projectData } = getStructuredData(lang)
 
   return (
     <Helmet>


### PR DESCRIPTION
## Summary
- join project descriptions into plain text
- expose `getStructuredData` to reuse structured data

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687d0bce69b483319303c4df6d00eab6