### PR TITLE
Patch three-stdlib exports and add unified fix script

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ Install dependencies with:
 npm install
 ```
 
+If Three.js packages fail after a fresh install, run the helper script:
+
+```bash
+npm run fix:three-all
+```
+This reinstalls compatible versions, patches `three-stdlib` and replaces
+legacy example imports.
+
 ## Development
 
 Start the Vite development server:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "fix:deps": "ts-node --loader ts-node/esm scripts/fix-deps.ts",
     "fix:three-deps": "ts-node --loader ts-node/esm scripts/fix-three-deps.ts",
     "fix:three-missing": "ts-node --loader ts-node/esm scripts/fix-three-missing.ts",
-    "fix:three-all": "npm run fix:three-deps && npm run fix:three-missing"
+    "fix:three-all": "ts-node --loader ts-node/esm scripts/fix-three-all.ts"
   },
   "dependencies": {
     "@emailjs/browser": "^4.4.1",

--- a/scripts/fix-three-all.ts
+++ b/scripts/fix-three-all.ts
@@ -1,0 +1,8 @@
+import { execSync } from 'child_process';
+
+function run(script: string) {
+  execSync(`ts-node --loader ts-node/esm ${script}`, { stdio: 'inherit' });
+}
+
+run('scripts/fix-three-deps.ts');
+run('scripts/fix-three-missing.ts');

--- a/scripts/fix-three-deps.ts
+++ b/scripts/fix-three-deps.ts
@@ -90,4 +90,20 @@ async function downloadMissingFiles() {
 
 downloadMissingFiles().then(() => {
   console.log("🚀 Tous les fichiers nécessaires ont été restaurés.");
+  // Patch three-stdlib exports so these files can be imported
+  const stdlibPkgPath = join("node_modules", "three-stdlib", "package.json");
+  if (existsSync(stdlibPkgPath)) {
+    const pkg = JSON.parse(fs.readFileSync(stdlibPkgPath, "utf8")) as Record<string, any>;
+    pkg.exports = {
+      ...(pkg.exports || {}),
+      "./nodes": "../three/examples/jsm/nodes/Nodes.js",
+      "./shaders/AdditiveBlendingShader": "../three/examples/jsm/shaders/AdditiveBlendingShader.js",
+      "./renderers/webgpu/WebGPURenderer": "../three/examples/jsm/renderers/webgpu/WebGPURenderer.js",
+      "./nodes/tsl/tsl": "../three/examples/jsm/nodes/tsl/tsl.js",
+    };
+    fs.writeFileSync(stdlibPkgPath, JSON.stringify(pkg, null, 2));
+    console.log("🛠️  three-stdlib exports patched.");
+  } else {
+    console.warn("⚠️  three-stdlib package.json introuvable.");
+  }
 });


### PR DESCRIPTION
## Summary
- patch `three-stdlib` exports during dependency fix
- add `fix-three-all.ts` to run both fix scripts
- wire new script into `package.json`
- document usage in the README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687d0c0785d883318cf9df78a590123b