### PR TITLE
Fix StructuredSEO descriptions

### DIFF
--- a/src/components/StructuredSEO.tsx
+++ b/src/components/StructuredSEO.tsx
@@ -21,14 +21,20 @@ export const getStructuredData = (lang: 'fr' | 'en') => {
     url: SITE_URL,
   }
 
-  const projectData = projects.map((p) => ({
-    '@context': 'https://schema.org',
-    '@type': 'CreativeWork',
-    name: p.title[lang],
-    description: p.description[lang].join(' '),
-    image: p.image,
-    ...(p.url ? { url: p.url } : {}),
-  }))
+  const projectData = projects.map((p) => {
+    const description = Array.isArray(p.description[lang])
+      ? p.description[lang].join(' ')
+      : p.description[lang]
+
+    return {
+      '@context': 'https://schema.org',
+      '@type': 'CreativeWork',
+      name: p.title[lang],
+      description,
+      image: p.image,
+      ...(p.url ? { url: p.url } : {}),
+    }
+  })
 
   return { websiteData, personData, projectData }
 }

--- a/tests/structuredSeo.test.ts
+++ b/tests/structuredSeo.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { getStructuredData } from '../src/components/StructuredSEO'
+import { projects } from '../src/data/projects'
+
+;(['en', 'fr'] as const).forEach((lang) => {
+  describe(`getStructuredData (${lang})`, () => {
+    it('returns joined description strings', () => {
+      const { projectData } = getStructuredData(lang)
+      projectData.forEach((data, idx) => {
+        expect(typeof data.description).toBe('string')
+        const expected = projects[idx].description[lang].join(' ')
+        expect(data.description).toBe(expected)
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- ensure project descriptions are joined before JSON-LD serialization
- test that getStructuredData returns string descriptions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687d0e481c1c8331a7f866a8b3000948