### PR TITLE
Add test for translation keys

### DIFF
--- a/tests/componentKeys.test.ts
+++ b/tests/componentKeys.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import i18n from '../src/i18n';
+
+const keys = [
+  'hero.title',
+  'hero.discoverKr',
+  'hero.scroll',
+  'about.title',
+  'about.summary',
+  'skills.title',
+  'skills.subtitle',
+  'projects.title',
+  'projects.subtitle',
+  'experience.title',
+  'experience.subtitle',
+  'contact.title',
+  'contact.description',
+  'resumeSelector.aria',
+  'resumeSelector.choose',
+  'chat.title',
+  'chat.subtitle',
+  'floatingAgentIA.open',
+  'floatingAgentIA.close',
+  'footer.rights',
+  'contactForm.nameLabel',
+  'contactForm.emailLabel',
+  'contactForm.messageLabel',
+  'contactForm.send'
+];
+
+describe('component translation keys', () => {
+  it('resolve for both languages', () => {
+    keys.forEach((key) => {
+      const en = i18n.t(key, { lng: 'en' });
+      const fr = i18n.t(key, { lng: 'fr' });
+      expect(en).not.toBe(key);
+      expect(fr).not.toBe(key);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- ensure translation keys exist for main components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687d0e487cf483318e589f562fd28413