### PR TITLE
Add debug:all script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "vitest run",
     "clean:binaries": "ts-node --loader ts-node/esm --project tsconfig.node.json scripts/clean-binaries.ts",
     "fix:deps": "ts-node --loader ts-node/esm scripts/fix-deps.ts",
-    "fix:three": "ts-node --loader ts-node/esm scripts/fix-three.ts"
+    "fix:three": "ts-node --loader ts-node/esm scripts/fix-three.ts",
+    "debug:all": "ts-node --loader ts-node/esm scripts/debug-all.ts"
   },
   "dependencies": {
     "@emailjs/browser": "^4.4.1",

--- a/scripts/debug-all.ts
+++ b/scripts/debug-all.ts
@@ -1,0 +1,1 @@
+console.log('Running debug-all script...');

--- a/scripts/fix-three.ts
+++ b/scripts/fix-three.ts
@@ -82,7 +82,7 @@ async function downloadMissingFiles() {
 async function patchStdlib() {
   const stdlibPkgPath = join('node_modules', 'three-stdlib', 'package.json');
   if (existsSync(stdlibPkgPath)) {
-    const pkg = JSON.parse(fs.readFileSync(stdlibPkgPath, 'utf8')) as Record<string, any>;
+    const pkg = JSON.parse(fs.readFileSync(stdlibPkgPath, 'utf8')) as Record<string, unknown>;
     pkg.exports = {
       ...(pkg.exports || {}),
       './nodes': '../three/examples/jsm/nodes/Nodes.js',


### PR DESCRIPTION
## Summary
- add `debug:all` npm script
- add a simple `scripts/debug-all.ts`
- fix lint error in `scripts/fix-three.ts`

## Testing
- `npm run lint`
- `npm test`
- `npm run debug:all` *(fails: Unknown or unexpected option: --loader)*

------
https://chatgpt.com/codex/tasks/task_b_687d181196208331925f7db7ada07ca7