### PR TITLE
Fix lint error in debug-all script

### DIFF
--- a/scripts/debug-all.ts
+++ b/scripts/debug-all.ts
@@ -12,7 +12,7 @@ execSync('npm install --legacy-peer-deps', { stdio: 'inherit' });
 console.log('🛠️  Patching three-stdlib exports...');
 const pkgPath = join('node_modules', 'three-stdlib', 'package.json');
 if (fs.existsSync(pkgPath)) {
-  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as Record<string, any>;
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as Record<string, unknown>;
   pkg.exports = {
     './package.json': './package.json',
     './*': './*',


### PR DESCRIPTION
## Summary
- adjust type for JSON parsing in `debug-all.ts`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687d2312939083319fcd303b707823be