### PR TITLE
Refactor structured data utility

### DIFF
--- a/scripts/debug-all.ts
+++ b/scripts/debug-all.ts
@@ -12,7 +12,7 @@ execSync('npm install --legacy-peer-deps', { stdio: 'inherit' });
 console.log('🛠️  Patching three-stdlib exports...');
 const pkgPath = join('node_modules', 'three-stdlib', 'package.json');
 if (fs.existsSync(pkgPath)) {
-  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as Record<string, any>;
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as Record<string, unknown>;
   pkg.exports = {
     './package.json': './package.json',
     './*': './*',

--- a/src/components/StructuredSEO.tsx
+++ b/src/components/StructuredSEO.tsx
@@ -2,42 +2,7 @@ import React from 'react'
 import { Helmet } from 'react-helmet'
 import { useTranslation } from 'react-i18next'
 import { projects } from '../data/projects'
-
-const SITE_URL = 'https://karimhammouche.com'
-
-export const getStructuredData = (lang: 'fr' | 'en') => {
-  const websiteData = {
-    '@context': 'https://schema.org',
-    '@type': 'WebSite',
-    url: SITE_URL,
-    name: 'Karim Hammouche | Portfolio',
-    inLanguage: lang,
-  }
-
-  const personData = {
-    '@context': 'https://schema.org',
-    '@type': 'Person',
-    name: 'Karim Hammouche',
-    url: SITE_URL,
-  }
-
-  const projectData = projects.map((p) => {
-    const description = Array.isArray(p.description[lang])
-      ? p.description[lang].join(' ')
-      : p.description[lang]
-
-    return {
-      '@context': 'https://schema.org',
-      '@type': 'CreativeWork',
-      name: p.title[lang],
-      description,
-      image: p.image,
-      ...(p.url ? { url: p.url } : {}),
-    }
-  })
-
-  return { websiteData, personData, projectData }
-}
+import { getStructuredData } from '../utils/structuredData'
 
 const StructuredSEO: React.FC = () => {
   const { i18n } = useTranslation()

--- a/src/utils/structuredData.ts
+++ b/src/utils/structuredData.ts
@@ -1,0 +1,37 @@
+const SITE_URL = 'https://karimhammouche.com'
+
+import { projects } from '../data/projects'
+
+export const getStructuredData = (lang: 'fr' | 'en') => {
+  const websiteData = {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    url: SITE_URL,
+    name: 'Karim Hammouche | Portfolio',
+    inLanguage: lang,
+  }
+
+  const personData = {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name: 'Karim Hammouche',
+    url: SITE_URL,
+  }
+
+  const projectData = projects.map((p) => {
+    const description = Array.isArray(p.description[lang])
+      ? p.description[lang].join(' ')
+      : p.description[lang]
+
+    return {
+      '@context': 'https://schema.org',
+      '@type': 'CreativeWork',
+      name: p.title[lang],
+      description,
+      image: p.image,
+      ...(p.url ? { url: p.url } : {}),
+    }
+  })
+
+  return { websiteData, personData, projectData }
+}

--- a/tests/structuredSeo.test.ts
+++ b/tests/structuredSeo.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getStructuredData } from '../src/components/StructuredSEO'
+import { getStructuredData } from '../src/utils/structuredData'
 import { projects } from '../src/data/projects'
 
 ;(['en', 'fr'] as const).forEach((lang) => {


### PR DESCRIPTION
## Summary
- extract `getStructuredData` into `src/utils/structuredData.ts`
- update `StructuredSEO.tsx` to import the util and only export a component
- fix linting error in `scripts/debug-all.ts`
- update tests to reference the new util

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687d2313a5888331ae14df1797cf8ccf