### PR TITLE
Remove unused optimizeDeps and add cleaning script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "codex:fix": "tsx scripts/fix-portfolio.ts",
     "test": "vitest run",
     "clean:binaries": "tsx scripts/clean-binaries.ts",
+    "clean:vite": "tsx scripts/clean-vite-optimize.ts",
     "fix:deps": "tsx scripts/fix-deps.ts",
     "fix:three": "tsx scripts/fix-three.ts",
     "debug:all": "npm run fix:three && npm run dev",

--- a/scripts/clean-vite-optimize.ts
+++ b/scripts/clean-vite-optimize.ts
@@ -1,0 +1,7 @@
+import { rmSync } from 'fs';
+import path from 'path';
+
+const optimizeDir = path.resolve('node_modules/.vite');
+rmSync(optimizeDir, { recursive: true, force: true });
+console.log(`🧹 Removed ${optimizeDir}`);
+

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,12 +14,7 @@ export default defineConfig({
     }),
   ],
   optimizeDeps: {
-    include: [
-      'three',
-      'three-stdlib/nodes',
-      'three-stdlib/shaders/AdditiveBlendingShader',
-      'three-stdlib/renderers/webgpu/WebGPURenderer',
-    ],
+    include: ['three'],
     exclude: [
       'lucide-react',
       'three/webgpu',


### PR DESCRIPTION
## Summary
- simplify optimizeDeps config
- add a script to clear Vite's optimize cache
- expose `clean:vite` npm script

## Testing
- `npm test`
- `npm run build` *(fails: Could not load three/webgpu)*

------
https://chatgpt.com/codex/tasks/task_b_687d27334d68833185d723205b6ad45d