### PR TITLE
Add postinstall patch for three-globe

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "fix:deps": "tsx scripts/fix-deps.ts",
     "fix:three": "tsx scripts/fix-three.ts",
     "debug:all": "npm run fix:three && npm run dev",
-    "postinstall": "tsx scripts/patch-three-stdlib.ts",
+    "postinstall": "tsx scripts/patch-three-stdlib.ts && tsx scripts/fix-three-globe.ts",
     "clean:optimizeDeps": "tsx scripts/clean-vite-optimize.ts"
   },
   "dependencies": {

--- a/scripts/fix-three-globe.ts
+++ b/scripts/fix-three-globe.ts
@@ -1,0 +1,23 @@
+import fs from 'fs'
+import path from 'path'
+
+const filePath = path.resolve('node_modules/three-globe/dist/three-globe.mjs')
+
+try {
+  if (!fs.existsSync(filePath)) {
+    console.warn('⚠️  three-globe not found, skipping patch.')
+    process.exit(0)
+  }
+  const content = fs.readFileSync(filePath, 'utf8')
+  const regex = /(import\s+\{[^}]*WebGPURenderer[^}]*\}\s+from\s+['"]three\/webgpu['"];?)/
+  if (regex.test(content)) {
+    const updated = content.replace(regex, '// $1')
+    fs.writeFileSync(filePath, updated)
+    console.log('✅ Patched three-globe to comment out WebGPURenderer import.')
+  } else {
+    console.log('ℹ️  WebGPURenderer import not found, skipping.')
+  }
+} catch (err) {
+  console.error('❌ Failed to patch three-globe:', err)
+  process.exit(1)
+}


### PR DESCRIPTION
## Summary
- patch three-globe's WebGPU import after install
- hook new patch into the `postinstall` lifecycle

## Testing
- `npm run postinstall`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687d2d590d2c8331b03215d186f7ea28