### PR TITLE
Suppress console error in tests

### DIFF
--- a/tests/translation.test.ts
+++ b/tests/translation.test.ts
@@ -3,8 +3,10 @@ import { translateText, LIBRETRANSLATE_URL } from '../src/utils/translation';
 
 describe('translateText', () => {
   const originalFetch = global.fetch;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn> | undefined;
 
   afterEach(() => {
+    consoleErrorSpy?.mockRestore();
     vi.restoreAllMocks();
     global.fetch = originalFetch;
   });
@@ -30,6 +32,7 @@ describe('translateText', () => {
   });
 
   it('returns original text on fetch error', async () => {
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     global.fetch = vi.fn().mockRejectedValue(new Error('network'));
 
     const result = await translateText('Hello', 'en', 'fr');


### PR DESCRIPTION
## Summary
- silence expected console errors during translation tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687d3d432ffc833189b5195217d326c0