### PR TITLE
Patch three-render-objects import

### DIFF
--- a/scripts/fix-react-globe.ts
+++ b/scripts/fix-react-globe.ts
@@ -2,6 +2,12 @@ import fs from 'fs'
 import path from 'path'
 
 const filePath = path.resolve('node_modules/react-globe.gl/dist/react-globe.gl.mjs')
+const troFilePaths = [
+  path.resolve('node_modules/three-render-objects/dist/three-render-objects.mjs'),
+  path.resolve(
+    'node_modules/globe.gl/node_modules/three-render-objects/dist/three-render-objects.mjs',
+  ),
+]
 
 try {
   if (!fs.existsSync(filePath)) {
@@ -16,6 +22,34 @@ try {
     console.log('✅ Removed three/webgpu and three/tsl imports from react-globe.gl.')
   } else {
     console.log('ℹ️  No three/webgpu or three/tsl imports found in react-globe.gl.')
+  }
+
+  for (const troFilePath of troFilePaths) {
+    if (fs.existsSync(troFilePath)) {
+      const troContent = fs.readFileSync(troFilePath, 'utf8')
+      const troRegex = /^import.*WebGPURenderer.*from ['"]three\/webgpu['"];?\n?/gm
+      const troUpdated = troContent.replace(troRegex, '')
+      if (troUpdated !== troContent) {
+        fs.writeFileSync(troFilePath, troUpdated)
+        console.log(
+          `✅ Removed WebGPURenderer import from ${path.relative(
+            process.cwd(),
+            troFilePath,
+          )}.`,
+        )
+      } else {
+        console.log(
+          `ℹ️  No WebGPURenderer import found in ${path.relative(
+            process.cwd(),
+            troFilePath,
+          )}.`,
+        )
+      }
+    } else {
+      console.warn(
+        `⚠️  ${path.relative(process.cwd(), troFilePath)} not found, skipping fix.`,
+      )
+    }
   }
 } catch (err) {
   console.error('❌ Failed to patch react-globe.gl:', err)


### PR DESCRIPTION
## Summary
- update fix-react-globe script to also patch three-render-objects
- search for three-render-objects in globe.gl and remove WebGPU import if present

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687d3d426f788331afd123d6214c2d92