### PR TITLE
Add fallbackAI greeting test

### DIFF
--- a/tests/fallbackAI.test.ts
+++ b/tests/fallbackAI.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { askFallbackAI } from '../src/utils/fallbackAI';
+
+const enGreetings = ['Hello! How can I help you?', 'Hi there! What can I do for you?'];
+const frGreetings = ['Bonjour ! Comment puis-je vous aider ?', 'Salut ! Que puis-je faire pour vous ?'];
+
+describe('askFallbackAI', () => {
+  it('returns an English greeting', () => {
+    const result = askFallbackAI('Hello');
+    expect(enGreetings).toContain(result);
+  });
+
+  it('returns a French greeting', () => {
+    const result = askFallbackAI('Bonjour');
+    expect(frGreetings).toContain(result);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `askFallbackAI` greeting responses in English and French

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687e00c83a608331ab2442e4a461fab9