### PR TITLE
Add start flag for codex fix script

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ This reinstalls compatible versions, patches `three-stdlib` and replaces legacy 
 If dependencies break inside the Codex workspace, use:
 
 ```bash
-npm run codex:fix
+npm run codex:fix -- --start
 ```
-This wipes `node_modules`, reinstalls packages with legacy peer deps, patches `three-stdlib` and fixes outdated example imports before launching the dev server.
+This wipes `node_modules`, reinstalls packages with legacy peer deps, patches `three-stdlib` and fixes outdated example imports. Pass the `--start` flag to launch the dev server when the script finishes.
 It also removes unsupported WebGPU/TSL imports from `react-globe.gl`, which resolves build errors caused by Three.js examples.
 
 ### Troubleshooting

--- a/scripts/fix-portfolio.ts
+++ b/scripts/fix-portfolio.ts
@@ -84,7 +84,11 @@ async function main() {
   patchThreeStdlib();
   patchReactGlobe();
   await replaceImports();
-  runDev();
+  if (process.argv.includes('--start')) {
+    runDev();
+  } else {
+    console.log('ℹ️  Skipping dev server. Pass --start to launch it automatically.');
+  }
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary
- make `scripts/fix-portfolio.ts` start the dev server only when `--start` flag is passed
- document new flag usage in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687e248216b083319dada68c2451ba22