### PR TITLE
Add light class toggle in dark mode hook

### DIFF
--- a/src/hooks/useDarkMode.ts
+++ b/src/hooks/useDarkMode.ts
@@ -16,6 +16,7 @@ const useDarkMode = (): [Theme, () => void] => {
   useEffect(() => {
     const root = document.documentElement;
     root.classList.toggle('dark', theme === 'dark');
+    root.classList.toggle('light', theme === 'light');
     localStorage.setItem('theme', theme);
   }, [theme]);
 


### PR DESCRIPTION
## Summary
- toggle the `light` class in `useDarkMode` just like `useTheme`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_687e29f46b54833187c06cfe449fde95