### PR TITLE
Update README codex fix section

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ If dependencies break inside the Codex workspace, use:
 ```bash
 npm run codex:fix -- --start
 ```
-This wipes `node_modules`, reinstalls packages with legacy peer deps, patches `three-stdlib` and fixes outdated example imports. Pass the `--start` flag to launch the dev server when the script finishes.
-It also removes unsupported WebGPU/TSL imports from `react-globe.gl`, which resolves build errors caused by Three.js examples.
+This wipes `node_modules`, reinstalls packages with legacy peer deps, patches `three-stdlib` and fixes outdated example imports.
+It also patches `three-globe` imports, removes unsupported WebGPU/TSL imports from `react-globe.gl` and ensures a proper `FrameTicker` export. Pass the `--start` flag to launch the dev server when the script finishes.
 
 ### Troubleshooting
 


### PR DESCRIPTION
## Summary
- document latest fix script updates for removing problematic imports
- mention `three-globe` patch and `FrameTicker` export in `codex:fix` section

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_687e3b1f6c98833187359e83e1742f0d