### PR TITLE
Refactor patch helpers

### DIFF
--- a/scripts/fix-react-globe.ts
+++ b/scripts/fix-react-globe.ts
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import path from 'path'
+import { removeThreeImports } from './utils/importFixers.ts'
 
 const filePath = path.resolve('node_modules/react-globe.gl/dist/react-globe.gl.mjs')
 const troFilePaths = [
@@ -15,8 +16,7 @@ try {
     process.exit(0)
   }
   const content = fs.readFileSync(filePath, 'utf8')
-  const regex = /^import.*from ['"]three\/(?:webgpu|tsl)['"];?\n?/gm
-  const updated = content.replace(regex, '')
+  const updated = removeThreeImports(content)
   if (updated !== content) {
     fs.writeFileSync(filePath, updated)
     console.log('✅ Removed three/webgpu and three/tsl imports from react-globe.gl.')

--- a/scripts/fix-vite-globe.ts
+++ b/scripts/fix-vite-globe.ts
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import path from 'path'
+import { removeThreeImports } from './utils/importFixers.ts'
 
 const filePath = path.resolve('node_modules/.vite/deps/react-globe_gl.js')
 
@@ -9,8 +10,7 @@ try {
     process.exit(0)
   }
   const content = fs.readFileSync(filePath, 'utf8')
-  const regex = /^import.*from ['"]three\/(?:webgpu|tsl)['"];?\n?/gm
-  const updated = content.replace(regex, '')
+  const updated = removeThreeImports(content)
   if (updated !== content) {
     fs.writeFileSync(filePath, updated)
     console.log('✅ Removed three/webgpu and three/tsl imports from react-globe_gl.js.')

--- a/scripts/patch-frame-ticker.ts
+++ b/scripts/patch-frame-ticker.ts
@@ -1,0 +1,46 @@
+import fs from 'fs'
+import path from 'path'
+import { removeThreeImports, rewriteFrameTickerImports } from './utils/importFixers.ts'
+import { patchFrameTickerExport } from './utils/patchFrameTicker.ts'
+
+function patchReactGlobeFiles() {
+  console.log('🛠️  Patching react-globe.gl imports...')
+  const files = [
+    path.join('node_modules', 'react-globe.gl', 'dist', 'react-globe.gl.mjs'),
+    path.join('node_modules', '.vite', 'deps', 'react-globe_gl.js'),
+  ]
+  for (const filePath of files) {
+    if (!fs.existsSync(filePath)) {
+      console.warn(`⚠️  ${filePath} not found, skipping.`)
+      continue
+    }
+    let content = fs.readFileSync(filePath, 'utf8')
+    content = removeThreeImports(content)
+    content = rewriteFrameTickerImports(content)
+    fs.writeFileSync(filePath, content)
+    console.log(`✅ Patched ${filePath}`)
+  }
+}
+
+function patchThreeGlobe() {
+  console.log('🛠️  Patching three-globe imports...')
+  const filePath = path.join('node_modules', 'three-globe', 'dist', 'three-globe.mjs')
+  if (!fs.existsSync(filePath)) {
+    console.warn('⚠️  three-globe.mjs not found, skipping.')
+    return
+  }
+  let content = fs.readFileSync(filePath, 'utf8')
+  content = removeThreeImports(content)
+  content = rewriteFrameTickerImports(content)
+  fs.writeFileSync(filePath, content)
+  console.log('✅ Patched three-globe.mjs')
+}
+
+try {
+  patchReactGlobeFiles()
+  patchThreeGlobe()
+  patchFrameTickerExport()
+} catch (err) {
+  console.error('❌ Failed to patch frame-ticker:', err)
+  process.exit(1)
+}

--- a/scripts/utils/importFixers.ts
+++ b/scripts/utils/importFixers.ts
@@ -1,0 +1,11 @@
+
+export function removeThreeImports(content: string): string {
+  return content.replace(/^import.*from ['"]three\/(?:webgpu|tsl)['"];?\n?/gm, '')
+}
+
+export function rewriteFrameTickerImports(content: string): string {
+  return content.replace(
+    /import\s+FrameTicker\s+from\s+['"]frame-ticker['"]/g,
+    'import { FrameTicker } from "frame-ticker"',
+  )
+}

--- a/scripts/utils/patchFrameTicker.ts
+++ b/scripts/utils/patchFrameTicker.ts
@@ -1,0 +1,55 @@
+import fs from 'fs'
+import { join } from 'path'
+
+export function patchFrameTickerExport() {
+  console.log('🔧 Checking FrameTicker.js export...')
+  const filePath = join('node_modules', 'frame-ticker', 'dist', 'FrameTicker.js')
+
+  if (!fs.existsSync(filePath)) {
+    console.warn(`⚠️  ${filePath} not found, creating it manually...`)
+    const newContent = `
+export class FrameTicker {
+  constructor(callback) {
+    this.callback = callback;
+    this.running = false;
+    this.rafId = null;
+  }
+
+  start() {
+    if (this.running) return;
+    this.running = true;
+    const loop = () => {
+      this.callback();
+      this.rafId = requestAnimationFrame(loop);
+    };
+    loop();
+  }
+
+  stop() {
+    if (!this.running) return;
+    this.running = false;
+    cancelAnimationFrame(this.rafId);
+    this.rafId = null;
+  }
+}
+    `
+    fs.mkdirSync(join('node_modules', 'frame-ticker', 'dist'), { recursive: true })
+    fs.writeFileSync(filePath, newContent.trim())
+    console.log(`✅ Created ${filePath}`)
+    return
+  }
+
+  let content = fs.readFileSync(filePath, 'utf8')
+
+  if (/export\s+default\s+FrameTicker/.test(content)) {
+    content = content.replace(/export\s+default\s+FrameTicker/, 'export { FrameTicker }')
+    fs.writeFileSync(filePath, content)
+    console.log(`✅ Replaced default export in ${filePath}`)
+  } else if (!/export\s+\{?\s*FrameTicker\s*\}?/.test(content)) {
+    content += `\nexport { FrameTicker };`
+    fs.writeFileSync(filePath, content)
+    console.log(`✅ Added named export in ${filePath}`)
+  } else {
+    console.log(`✅ Export already correct in ${filePath}`)
+  }
+}


### PR DESCRIPTION
## Summary
- extract utilities for removing webgpu/tsl imports and rewriting FrameTicker imports
- share helpers in fix-portfolio, fix-react-globe and fix-vite-globe scripts
- add patch-frame-ticker script
- move FrameTicker export patch to util

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687e4242560083318af0893a8e1fbc7a