### PR TITLE
Add final FrameTicker fix script

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ npm run patch:frame-ticker
 ```
 This updates `frame-ticker` and rewrites imports in `react-globe.gl` and `three-globe` for compatibility.
 
+Run `tsx scripts/final-frame-ticker-fix.ts` if issues persist after patching.
+
 ### Troubleshooting
 
 Run the debug command if you keep seeing errors with Three.js or Vite:

--- a/scripts/final-frame-ticker-fix.ts
+++ b/scripts/final-frame-ticker-fix.ts
@@ -1,0 +1,25 @@
+import fs from 'fs'
+import path from 'path'
+
+const filePath = path.resolve('node_modules/three-globe/dist/three-globe.mjs')
+
+try {
+  if (!fs.existsSync(filePath)) {
+    console.warn(`⚠️  ${filePath} not found, skipping.`)
+    process.exit(0)
+  }
+  const content = fs.readFileSync(filePath, 'utf8')
+  const updated = content.replace(
+    /import\s+FrameTicker\s+from\s+['"]frame-ticker['"]/g,
+    'import { FrameTicker } from "frame-ticker"',
+  )
+  if (updated !== content) {
+    fs.writeFileSync(filePath, updated)
+    console.log(`✅ Updated FrameTicker import in ${path.relative(process.cwd(), filePath)}`)
+  } else {
+    console.log('ℹ️  No default FrameTicker import found.')
+  }
+} catch (err) {
+  console.error('❌ Failed to apply final FrameTicker fix:', err)
+  process.exit(1)
+}


### PR DESCRIPTION
## Summary
- add `final-frame-ticker-fix.ts` for last-minute patches
- mention the script in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687e48d049a48331b255d501cbc57528