### PR TITLE
Clarify setup steps for linting and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,13 +108,23 @@ npm run build
 
 ## Linting and Tests
 
+Before running the linter or test suite, install all dependencies:
+
+```bash
+npm install
+# or
+npm run fix:three
+```
+
+Missing packages will make `npm run lint` and `npm test` fail with "not found" errors.
+
 Run ESLint:
 
 ```bash
 npm run lint
 ```
 
-This project uses [Vitest](https://vitest.dev/) for unit tests. Install dependencies first with `npm install` (run `npm run fix:three` if the install fails), then run the tests with:
+This project uses [Vitest](https://vitest.dev/) for unit tests. After installing dependencies, run:
 
 ```bash
 npm test


### PR DESCRIPTION
## Summary
- update the `Linting and Tests` section to note running `npm install` or `npm run fix:three` before linting or testing
- document that missing packages will cause "not found" errors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_687e48d10cac8331a3a4e9a6a3180f94