### PR TITLE
Implement getCurrentLang utility and refactor components

### DIFF
--- a/src/components/CountrySearch.tsx
+++ b/src/components/CountrySearch.tsx
@@ -2,20 +2,20 @@ import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { countries } from '../data/countries';
 import { useCountryStore } from '../store/countrySearch';
+import { getCurrentLang } from '../utils/getCurrentLang';
 
 const CountrySearch: React.FC = () => {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const search = useCountryStore((s) => s.search);
   const setSearch = useCountryStore((s) => s.setSearch);
   const setSelected = useCountryStore((s) => s.setSelected);
+  const lang = getCurrentLang();
 
   const results = useMemo(() => {
     return countries.filter((c) =>
-      c.name[i18n.language as 'fr' | 'en']
-        .toLowerCase()
-        .includes(search.toLowerCase()),
+      c.name[lang].toLowerCase().includes(search.toLowerCase()),
     );
-  }, [search, i18n.language]);
+  }, [search, lang]);
 
   return (
     <div className="space-y-2 max-w-md mx-auto">
@@ -40,7 +40,7 @@ const CountrySearch: React.FC = () => {
                 setSearch('');
               }}
             >
-              {c.name[i18n.language as 'fr' | 'en']}
+              {c.name[lang]}
             </li>
           ))}
         </ul>

--- a/src/components/ProjectCardsGrid.tsx
+++ b/src/components/ProjectCardsGrid.tsx
@@ -2,17 +2,19 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import ProjectCard from './ProjectCard';
 import { projects } from '../data/projects';
+import { getCurrentLang } from '../utils/getCurrentLang';
 
 const ProjectCardsGrid: React.FC = () => {
-  const { i18n } = useTranslation();
+  useTranslation();
+  const lang = getCurrentLang();
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
       {projects.map((project) => (
         <ProjectCard
           key={project.id}
-          title={project.title[i18n.language as 'fr' | 'en']}
-          description={project.description[i18n.language as 'fr' | 'en']}
+          title={project.title[lang]}
+          description={project.description[lang]}
           image={project.image}
           tags={project.tags}
           link={project.url}

--- a/src/components/StructuredSEO.tsx
+++ b/src/components/StructuredSEO.tsx
@@ -3,10 +3,11 @@ import { Helmet } from 'react-helmet'
 import { useTranslation } from 'react-i18next'
 import { projects } from '../data/projects'
 import { getStructuredData } from '../utils/structuredData'
+import { getCurrentLang } from '../utils/getCurrentLang'
 
 const StructuredSEO: React.FC = () => {
-  const { i18n } = useTranslation()
-  const lang = (i18n.language as 'fr' | 'en') || 'fr'
+  useTranslation()
+  const lang = getCurrentLang()
 
   const { websiteData, personData, projectData } = getStructuredData(lang)
 

--- a/src/utils/getCurrentLang.ts
+++ b/src/utils/getCurrentLang.ts
@@ -1,0 +1,5 @@
+import i18n from '../i18n';
+
+export function getCurrentLang(): 'fr' | 'en' {
+  return i18n.language === 'fr' || i18n.language === 'en' ? i18n.language : 'fr';
+}


### PR DESCRIPTION
## Summary
- add `getCurrentLang` helper under `src/utils`
- use `getCurrentLang` in `CountrySearch`, `ProjectCardsGrid`, and `StructuredSEO`
- update memoization logic in `CountrySearch`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687f0b364fcc8331ad2ecb89a9ea5fd5