### PR TITLE
Patch FrameTicker import

### DIFF
--- a/scripts/fixes/frame-ticker-patched.js
+++ b/scripts/fixes/frame-ticker-patched.js
@@ -1,0 +1,22 @@
+export default class FrameTicker {
+  constructor(callback) {
+    this.callback = callback;
+    this.running = false;
+    this.rafId = null;
+  }
+  start() {
+    if (this.running) return;
+    this.running = true;
+    const loop = () => {
+      this.callback();
+      this.rafId = requestAnimationFrame(loop);
+    };
+    loop();
+  }
+  stop() {
+    if (!this.running) return;
+    this.running = false;
+    cancelAnimationFrame(this.rafId);
+    this.rafId = null;
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, 'src'),
       three: path.resolve(__dirname, 'node_modules/three'),
+      'frame-ticker': 'scripts/fixes/frame-ticker-patched.js',
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- create a patched FrameTicker implementation
- map `frame-ticker` imports to the patched script in Vite config

## Testing
- `npm test`
- `npm run dev` *(stopped after launch)*


------
https://chatgpt.com/codex/tasks/task_b_687f167157888331be9a0fbfafe5f3ea