### PR TITLE
Add named export for FrameTicker

### DIFF
--- a/scripts/fixes/frame-ticker-patched.js
+++ b/scripts/fixes/frame-ticker-patched.js
@@ -1,4 +1,4 @@
-export default class FrameTicker {
+export class FrameTicker {
   constructor(callback) {
     this.callback = callback;
     this.running = false;
@@ -20,3 +20,4 @@ export default class FrameTicker {
     this.rafId = null;
   }
 }
+export default FrameTicker;


### PR DESCRIPTION
## Summary
- expose `FrameTicker` as a named export in the patched module

## Testing
- `npm test`
- `node -e "import('./scripts/fixes/frame-ticker-patched.js').then(m=>{console.log('named',typeof m.FrameTicker); console.log('default',typeof m.default);})"`

------
https://chatgpt.com/codex/tasks/task_b_687f2a6ee0788331b876e0e22bc57073