### PR TITLE
Add globe FrameTicker patch script

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "clean:binaries": "tsx scripts/clean-binaries.ts",
     "clean:optimizeDeps": "tsx scripts/clean-vite-optimize.ts",
     "debug:all": "npm run fix:three && npm run dev",
-    "postinstall": "tsx scripts/patch-three-stdlib.ts && tsx scripts/patch-frame-ticker.ts && tsx scripts/fix-react-globe.ts && tsx scripts/fix-vite-globe.ts && tsx scripts/patch-globe-frame-ticker.ts"
+    "postinstall": "tsx scripts/patch-three-stdlib.ts && tsx scripts/patch-frame-ticker.ts && tsx scripts/fix-react-globe.ts && tsx scripts/fix-vite-globe.ts && npm run patch:globe-frame-ticker"
   },
   "dependencies": {
     "@emailjs/browser": "^4.4.1",

--- a/scripts/patch-globe-frame-ticker.ts
+++ b/scripts/patch-globe-frame-ticker.ts
@@ -1,0 +1,43 @@
+import fs from 'fs'
+import path from 'path'
+import { removeThreeImports, rewriteFrameTickerImports } from './utils/importFixers.ts'
+
+function patchFile(filePath: string) {
+  if (!fs.existsSync(filePath)) {
+    console.warn(`⚠️  ${filePath} not found, skipping.`)
+    return
+  }
+  let content = fs.readFileSync(filePath, 'utf8')
+  content = removeThreeImports(content)
+  content = rewriteFrameTickerImports(content)
+  fs.writeFileSync(filePath, content)
+  console.log(`✅ Patched ${path.relative(process.cwd(), filePath)}`)
+}
+
+function patchGlobeGL() {
+  console.log('🛠️  Patching globe.gl imports...')
+  const base = path.resolve('node_modules/globe.gl/dist')
+  const files = [
+    'globe.gl.js',
+    'globe.gl.esm.js',
+    'globe.gl.module.js',
+  ].map((f) => path.join(base, f))
+  for (const file of files) {
+    patchFile(file)
+  }
+}
+
+function patchThreeGlobe() {
+  console.log('🛠️  Patching three-globe imports...')
+  const filePath = path.resolve('node_modules/three-globe/dist/three-globe.mjs')
+  patchFile(filePath)
+}
+
+try {
+  patchGlobeGL()
+  patchThreeGlobe()
+  console.log('✅ Globe FrameTicker patch complete.')
+} catch (err) {
+  console.error('❌ Failed to patch globe FrameTicker:', err)
+  process.exit(1)
+}


### PR DESCRIPTION
## Summary
- add a patch script for Globe frame ticker imports
- run this new script in the postinstall hook

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687f4f0690dc833182e9cf54f2edb73f