### PR TITLE
Add three-globe TSL cleanup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ npm run fix:three
 This reinstalls compatible versions, patches `three-stdlib`, copies required
 example files from `scripts/assets/three` and replaces legacy imports.
 
+If build errors mention `three/tsl`, strip those imports from `three-globe`:
+
+```bash
+npm run fix:tsl
+```
+
 ### `codex:fix` helper
 
 If dependencies break inside the Codex workspace, use:

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "fix:deps": "tsx scripts/fix-deps.ts",
     "fix:three": "tsx scripts/fix-three.ts",
     "fix:globe": "tsx scripts/fix-globe.ts",
+    "fix:tsl": "tsx scripts/fix-three-globe-tsl.ts",
     "clean:binaries": "tsx scripts/clean-binaries.ts",
     "clean:optimizeDeps": "tsx scripts/clean-vite-optimize.ts",
     "debug:all": "npm run patch:three-stdlib && npm run patch:frame-ticker && npm run patch:react-globe && npm run patch:vite-globe && npm run fix:three && npm run fix:globe && npm run dev",

--- a/scripts/fix-three-globe-tsl.ts
+++ b/scripts/fix-three-globe-tsl.ts
@@ -1,0 +1,24 @@
+import fs from 'fs/promises'
+import path from 'path'
+import fg from 'fast-glob'
+
+async function main() {
+  const pattern = 'node_modules/three-globe/**/*.mjs'
+  const files = await fg(pattern, { dot: true })
+  for (const file of files) {
+    const content = await fs.readFile(file, 'utf8')
+    const lines = content.split(/\r?\n/)
+    const filtered = lines.filter(
+      (line) => !/from ['"]three\/tsl['"]/.test(line),
+    )
+    if (filtered.length !== lines.length) {
+      await fs.writeFile(file, filtered.join('\n'))
+      console.log(`✅ Fixed ${path.relative(process.cwd(), file)}`)
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error('❌ Failed to remove three/tsl imports:', err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- add `scripts/fix-three-globe-tsl.ts` to strip `three/tsl` imports
- wire up npm script `fix:tsl`
- document running the script in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687f63140d94833180c65839e8cfec59