### PR TITLE
Add Spanish greeting test for fallback AI

### DIFF
--- a/tests/fallbackAI.test.ts
+++ b/tests/fallbackAI.test.ts
@@ -3,6 +3,7 @@ import { askFallbackAI } from '../src/utils/fallbackAI';
 
 const enGreetings = ['Hello! How can I help you?', 'Hi there! What can I do for you?'];
 const frGreetings = ['Bonjour ! Comment puis-je vous aider ?', 'Salut ! Que puis-je faire pour vous ?'];
+const esGreetings = ['¡Hola! ¿Cómo puedo ayudarte?', '¡Buenos días! ¿En qué puedo asistirte?'];
 
 describe('askFallbackAI', () => {
   it('returns an English greeting', () => {
@@ -13,5 +14,10 @@ describe('askFallbackAI', () => {
   it('returns a French greeting', () => {
     const result = askFallbackAI('Bonjour');
     expect(frGreetings).toContain(result);
+  });
+
+  it('returns a Spanish greeting', () => {
+    const result = askFallbackAI('Hola');
+    expect(esGreetings).toContain(result);
   });
 });


### PR DESCRIPTION
## Summary
- extend fallbackAI tests with a Spanish greeting check

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687f683d353c833198789276386b21c4