### PR TITLE
Update postinstall behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,9 @@
     "fix:tsl": "tsx scripts/fix-three-globe-tsl.ts",
     "clean:binaries": "tsx scripts/clean-binaries.ts",
     "clean:optimizeDeps": "tsx scripts/clean-vite-optimize.ts",
-    "debug:all": "npm run patch:three-stdlib && npm run patch:frame-ticker && npm run patch:react-globe && npm run patch:vite-globe && npm run fix:three && npm run fix:globe && npm run fix:frame-ticker && npm run fix:tsl && npm run clean:optimizeDeps && npm run dev",
-    "postinstall": "npm run debug:all"
+    "debug:all": "npm run setup:all && npm run dev",
+    "postinstall": "npm run setup:all && if [ \"$RUN_DEV_AFTER_INSTALL\" = \"true\" ]; then npm run dev; fi",
+    "setup:all": "npm run patch:three-stdlib && npm run patch:frame-ticker && npm run patch:react-globe && npm run patch:vite-globe && npm run fix:three && npm run fix:globe && npm run fix:frame-ticker && npm run fix:tsl && npm run clean:optimizeDeps"
   },
   "dependencies": {
     "@emailjs/browser": "^4.4.1",


### PR DESCRIPTION
## Summary
- add new `setup:all` script for patching dependencies
- run `setup:all` in `postinstall` and only start the dev server when `RUN_DEV_AFTER_INSTALL=true`
- update `debug:all` to use `setup:all`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687f75e050c08331a6f0e4d439faccb4