### PR TITLE
Update README with npm install note for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ npm run codex:fix
 ```
 
 Missing packages will make `npm run lint` and `npm test` fail with "not found" errors.
+`npm test` relies on the local `vitest` binary, so run `npm install` (or the fix script) before executing the tests, including in CI.
 
 Run ESLint:
 


### PR DESCRIPTION
## Summary
- document that running `npm install` (or the fix script) is required before `npm test`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687f7d7a92748331a5c14a6899611fe3