### PR TITLE
Create patch script for three-render-objects

### DIFF
--- a/scripts/fix-three-globe-imports.ts
+++ b/scripts/fix-three-globe-imports.ts
@@ -14,7 +14,7 @@ if (!fs.existsSync(filePath)) {
   process.exit(1);
 }
 
-let content = fs.readFileSync(filePath, 'utf-8');
+const content = fs.readFileSync(filePath, 'utf-8');
 
 // ❌ Supprime les lignes qui importent "frame-ticker" ou "three/tsl"
 const cleaned = content

--- a/scripts/fix-three-render-objects.ts
+++ b/scripts/fix-three-render-objects.ts
@@ -1,0 +1,23 @@
+// scripts/fix-three-render-objects.ts
+
+import fs from 'fs';
+import path from 'path';
+
+const root = process.cwd();
+const filePath = path.join(
+  root,
+  'node_modules/globe.gl/node_modules/three-render-objects/dist/three-render-objects.mjs'
+);
+
+if (!fs.existsSync(filePath)) {
+  console.error('❌ Fichier introuvable :', filePath);
+  process.exit(1);
+}
+
+const content = fs.readFileSync(filePath, 'utf-8');
+
+// ✅ Patch : ajout d’un commentaire spécial pour désactiver l’analyse Vite
+const patched = `/* @vite-ignore */\n${content}`;
+
+fs.writeFileSync(filePath, patched, 'utf-8');
+console.log('✅ Patch appliqué à three-render-objects.mjs');


### PR DESCRIPTION
## Summary
- add a new script `scripts/fix-three-render-objects.ts` to prepend a Vite ignore comment
- clean up `scripts/fix-three-globe-imports.ts` after lint

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_687f82ffdee48331bb9bc42f819382c1