### PR TITLE
Add render objects fix and update setup scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,12 +23,13 @@
     "fix:three": "tsx scripts/fix-three.ts",
     "fix:globe": "tsx scripts/fix-globe.ts",
     "fix:tsl": "tsx scripts/fix-three-globe-tsl.ts",
+    "fix:render-objects": "tsx scripts/fix-render-objects.ts",
     "fix:three-globe-imports": "tsx scripts/fix-three-globe-imports.ts",
     "clean:binaries": "tsx scripts/clean-binaries.ts",
     "clean:optimizeDeps": "tsx scripts/clean-vite-optimize.ts",
     "debug:all": "npm run setup:all && npm run dev",
     "postinstall": "npm run setup:all && if [ \"$RUN_DEV_AFTER_INSTALL\" = \"true\" ]; then npm run dev; fi",
-    "setup:all": "npm run patch:three-stdlib && npm run patch:frame-ticker && npm run patch:react-globe && npm run patch:vite-globe && npm run fix:three && npm run fix:globe && npm run fix:frame-ticker && npm run fix:tsl && npm run clean:optimizeDeps"
+    "setup:all": "npm run patch:three-stdlib && npm run patch:frame-ticker && npm run patch:react-globe && npm run patch:vite-globe && npm run fix:three && npm run fix:globe && npm run fix:frame-ticker && npm run fix:tsl && npm run fix:render-objects && npm run clean:optimizeDeps"
   },
   "dependencies": {
     "@emailjs/browser": "^4.4.1",

--- a/scripts/fix-render-objects.ts
+++ b/scripts/fix-render-objects.ts
@@ -1,0 +1,28 @@
+// ✅ Fichier : scripts/fix-render-objects.ts
+// Objectif : patcher automatiquement le fichier three-render-objects.mjs pour corriger l'erreur d'analyse Vite
+
+import fs from 'fs'
+import path from 'path'
+
+const target = path.join(
+  process.cwd(),
+  'node_modules/globe.gl/node_modules/three-render-objects/dist/three-render-objects.mjs'
+)
+
+if (!fs.existsSync(target)) {
+  console.error('❌ Le fichier three-render-objects.mjs est introuvable.')
+  process.exit(1)
+}
+
+let code = fs.readFileSync(target, 'utf-8')
+
+// Vérifie si le patch a déjà été appliqué
+if (code.includes('/* @vite-ignore */')) {
+  console.log('✅ Patch déjà appliqué.')
+  process.exit(0)
+}
+
+// Ajoute le commentaire spécial pour désactiver l’analyse Vite
+const patched = '/* @vite-ignore */\n' + code
+fs.writeFileSync(target, patched, 'utf-8')
+console.log('✅ Patch ajouté avec succès à three-render-objects.mjs')


### PR DESCRIPTION
## Summary
- add `scripts/fix-render-objects.ts` script that patches three-render-objects
- add npm script `fix:render-objects`
- include this patch in `setup:all`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687f865d746c8331abbb7cf1d52f58e4