### PR TITLE
Remove react-globe from optimizeDeps

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,7 +18,6 @@ export default defineConfig({
       'lucide-react',
       'three/webgpu',
       'three/tsl',
-      'react-globe.gl', // 🛡️ Forcer Vite à ne pas le précompiler (important pour ton patch)
     ],
   },
   resolve: {


### PR DESCRIPTION
## Summary
- remove `react-globe.gl` from `optimizeDeps.exclude`

## Testing
- `npm test`
- `npm run lint` *(fails: unused vars in scripts/fix-portfolio.ts)*

------
https://chatgpt.com/codex/tasks/task_b_6881ade9fa688331a3809630ff6b70a1