### PR TITLE
Remove old globe troubleshooting notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,6 @@ npm run fix:three
 This reinstalls compatible versions, patches `three-stdlib`, copies required
 example files from `scripts/assets/three` and replaces legacy imports.
 
-If build errors mention `three/tsl`, strip those imports from `three-globe`:
-
-```bash
-npm run fix:tsl
-```
-
 ### `codex:fix` helper
 
 If dependencies break inside the Codex workspace, use:
@@ -58,18 +52,6 @@ If dependencies break inside the Codex workspace, use:
 npm run codex:fix -- --reinstall --start
 ```
 Add the `--reinstall` flag to wipe `node_modules` and reinstall packages with legacy peer deps. The script also patches `three-stdlib` and fixes outdated example imports.
-It patches `three-globe` imports, removes unsupported WebGPU/TSL imports from `react-globe.gl` and ensures a proper `FrameTicker` export. Pass the `--start` flag to launch the dev server when the script finishes.
-
-### FrameTicker patch
-
-Run the FrameTicker patch if globe libraries fail to load:
-
-```bash
-npm run patch:frame-ticker
-```
-This updates `frame-ticker` and rewrites imports in `react-globe.gl` and `three-globe` for compatibility.
-
-Run `tsx scripts/final-frame-ticker-fix.ts` if issues persist after patching.
 
 ### Troubleshooting
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1920,9 +1920,9 @@
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.52.0",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.52.0.tgz",
-      "integrity": "sha512-jbs3CV1f2+ge7sgBeEduboT9v/uGjF22v0yWi/5/XFn5tbM8MfWRccsMtsDwAwu24XK8H6wt2LJDiNnZLtx/bg==",
+      "version": "2.52.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.52.1.tgz",
+      "integrity": "sha512-IxYljprgl381j4SuFrW4JimjTb59WJ98DqxhMvEOJjpGJWuZ7kwttIWn7E4NBnvkYwZ948zJkJ7dSI6B0oO0Xw==",
       "license": "MIT",
       "dependencies": {
         "@supabase/auth-js": "2.71.1",
@@ -4039,9 +4039,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.189",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.189.tgz",
-      "integrity": "sha512-y9D1ntS1ruO/pZ/V2FtLE+JXLQe28XoRpZ7QCCo0T8LdQladzdcOVQZH/IWLVJvCw12OGMb6hYOeOAjntCmJRQ==",
+      "version": "1.5.190",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.190.tgz",
+      "integrity": "sha512-k4McmnB2091YIsdCgkS0fMVMPOJgxl93ltFzaryXqwip1AaxeDqKCGLxkXODDA5Ab/D+tV5EL5+aTx76RvLRxw==",
       "dev": true,
       "license": "ISC"
     },
@@ -8199,9 +8199,9 @@
       }
     },
     "node_modules/react-i18next": {
-      "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.6.0.tgz",
-      "integrity": "sha512-W135dB0rDfiFmbMipC17nOhGdttO5mzH8BivY+2ybsQBbXvxWIwl3cmeH3T9d+YPBSJu/ouyJKFJTtkK7rJofw==",
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.6.1.tgz",
+      "integrity": "sha512-uGrzSsOUUe2sDBG/+FJq2J1MM+Y4368/QW8OLEKSFvnDflHBbZhSd1u3UkW0Z06rMhZmnB/AQrhCpYfE5/5XNg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.27.6",


### PR DESCRIPTION
## Summary
- delete outdated globe troubleshooting steps from README
- run `npm install` to regenerate lockfile

## Testing
- `npm run lint` *(fails: 'path' and 'err' defined but never used)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6881adec9088833184183c719422cb92