### PR TITLE
Render starry background site-wide

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import TestFormSupabase from "./components/TestFormSupabase";
 import TravelMap from "./pages/TravelMap"; // ✅ version retenue
 import Blog from "./components/blog/Blog";
 import ArticlePage from "./components/blog/ArticlePage";
+import StarryBackground from "./components/blog/StarryBackground";
 import i18n from "./i18n";
 
 // 📈 Fonction pour initialiser Google Analytics
@@ -79,6 +80,7 @@ function App() {
   return (
     <div>
       <CursorEffect />
+      <StarryBackground />
       <>
         <SEO />
         <StructuredSEO />


### PR DESCRIPTION
## Summary
- load the StarryBackground component in `App.tsx`
- render `StarryBackground` once near the root so stars show on all pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6881af6b12548331a3004eec75385a52