### PR TITLE
Fix globe import for CountriesSection

### DIFF
--- a/src/components/CountriesSection.tsx
+++ b/src/components/CountriesSection.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import CountrySearch from './CountrySearch';
-import Globe from './Globe';
+import Globe from '@/components/Globe';
 
 const CountriesSection: React.FC = () => {
   const { t } = useTranslation();


### PR DESCRIPTION
## Summary
- update `CountriesSection` to import `Globe` using alias

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_6881bf1a4f7083318009406b7b334f40