### PR TITLE
Add earth textures and document LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+public/textures/*.jpg filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -22,3 +22,5 @@ loaded from [`src/data/visitedCountries.json`](src/data/visitedCountries.json)
 and the earth textures are stored in [`public/textures/`](public/textures/).
 Dark and light versions of the texture are swapped automatically based on the
 current theme.
+
+These images are tracked using **Git LFS**. Running `npm run clean:binaries` will delete binary files in `public/` and `assets/`, so make sure the globe textures are restored afterwards with `git checkout` or avoid cleaning them.

--- a/public/textures/earth-dark.jpg
+++ b/public/textures/earth-dark.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29e15dca52fe160b533b37d0fc23e4804ebf86ac7eabcf5a2e90ca3e9677647a
+size 720

--- a/public/textures/earth-light.jpg
+++ b/public/textures/earth-light.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c136cb7c8e21ca692edf07c609fabb64f47ceb3bcad7dfb59b5fb29cd133331
+size 369


### PR DESCRIPTION
## Summary
- add `.gitattributes` to track textures with Git LFS
- add `earth-dark.jpg` and `earth-light.jpg` texture images
- mention Git LFS and clean script in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6881c25eea3c83319addb8668c56fcc4