### PR TITLE
Update README country data path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ cp .env.example .env
 ## How the Globe Works
 
 The site features a 3D globe rendered with `react-globe.gl`. Country markers are
-loaded from [`src/data/visitedCountries.json`](src/data/visitedCountries.json)
-and the earth textures are stored in [`public/textures/`](public/textures/).
+defined in [`src/data/countries.ts`](src/data/countries.ts) (generated from
+[`data/countries.json`](data/countries.json)), and the earth textures are stored
+in [`public/textures/`](public/textures/).
 Dark and light versions of the texture are swapped automatically based on the
 current theme.
 


### PR DESCRIPTION
## Summary
- remove old reference to `src/data/visitedCountries.json`
- mention `src/data/countries.ts` and `data/countries.json` as the source for globe markers

## Testing
- `npm test`
- `npm run lint` *(fails: scripts/fix-portfolio.ts has unused vars)*

------
https://chatgpt.com/codex/tasks/task_b_6881e97146c88331b7b22c59e77298ae