### PR TITLE
Add Git LFS setup helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
   and `@react-three/rapier` **1.x** – newer major versions of these
   packages require React 19
 
+After cloning the repository, install Git LFS and enable it:
+
+```bash
+./scripts/setup-git-lfs.sh
+```
+
 ## Environment Variables
 
 Copy `.env.example` to `.env` and populate your EmailJS configuration:

--- a/scripts/setup-git-lfs.sh
+++ b/scripts/setup-git-lfs.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v git-lfs >/dev/null 2>&1; then
+  echo "Git LFS not found. Installing..."
+  if command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update && sudo apt-get install -y git-lfs
+  elif command -v brew >/dev/null 2>&1; then
+    brew install git-lfs
+  else
+    echo "Please install Git LFS manually."
+    exit 1
+  fi
+fi
+
+git lfs install


### PR DESCRIPTION
## Summary
- add a `setup-git-lfs.sh` script that installs and initializes Git LFS
- document running the script after cloning in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688219dd27688331b1ce408df01e9f04