### PR TITLE
feat: update experience and education translations

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -64,94 +64,128 @@
     "subtitle": "Professional background",
     "items": [
       {
-        "title": "Recycling Maintenance Technician",
+        "role": "Recycling Maintenance Technician",
         "company": "Rino Recycling",
-        "dates": "Oct 2024 – Apr 2025",
-        "tasks": [
-          "Operated and maintained recycling equipment",
-          "Ensured safety standards and logistics support"
-        ]
+        "description": [
+          "Operated and monitored recycling equipment",
+          "Preventive maintenance and troubleshooting",
+          "Sorting to quality standards and HSE compliance",
+          "Logistics support and team coordination"
+        ],
+        "date": "Oct 2024 – Apr 2025"
       },
       {
-        "title": "Library Assistant & Delivery Coordinator",
+        "role": "Library Assistant & Delivery Driver",
         "company": "Cœur d’Essonne Agglomération",
-        "dates": "Sep 2019 – Apr 2024",
-        "tasks": [
-          "Managed book loans and deliveries",
-          "Supervised drivers and maintained catalog systems"
-        ]
+        "description": [
+          "Shelving, loans/returns, and reader assistance",
+          "Delivery route coordination and driver supervision",
+          "Deliveries, fleet follow-up, and records keeping"
+        ],
+        "date": "Sep 2019 – Apr 2024"
       },
       {
-        "title": "Dishwasher / Waiter",
-        "company": "Sofitel",
-        "dates": "Apr 2019 – Aug 2019",
-        "tasks": [
-          "Assisted kitchen and kept areas clean",
-          "Served diners and handled orders"
-        ]
+        "role": "Dishwasher, Kitchen Assistant & Waiter",
+        "company": "Sofitel (Accor Hotels)",
+        "description": [
+          "Food prep, plating, and customer service",
+          "Kitchen cleaning and organization"
+        ],
+        "date": "Apr 2019 – Aug 2019"
       },
       {
-        "title": "Maintenance Technician",
+        "role": "Maintenance Technician",
         "company": "Aximum",
-        "dates": "Mar 2018 – Mar 2019",
-        "tasks": [
-          "Maintained and repaired traffic signals",
-          "Diagnosed issues and ensured compliance"
-        ]
+        "description": [
+          "Preventive/corrective maintenance of traffic signals",
+          "Troubleshooting, testing, and safety compliance"
+        ],
+        "date": "Mar 2018 – Mar 2019"
       },
       {
-        "title": "Environmental Technician",
+        "role": "Environmental Technician",
         "company": "Cœur d’Essonne Agglomération",
-        "dates": "Mar 2017 – Feb 2018",
-        "tasks": [
-          "Inspected sanitation networks and enforced regulations",
-          "Collected data and resolved environmental issues"
-        ]
+        "description": [
+          "Sanitation network inspections and sampling",
+          "Analysis reports and regulatory compliance"
+        ],
+        "date": "Mar 2017 – Feb 2018"
       },
       {
-        "title": "Sales Agent",
+        "role": "Station Sales Agent",
         "company": "SNCF Réseau",
-        "dates": "Oct 2016 – Feb 2017",
-        "tasks": [
-          "Assisted passengers and sold tickets",
-          "Managed incidents using SNCF systems"
-        ]
+        "description": [
+          "Ticket sales and passenger assistance",
+          "Incident handling and communication"
+        ],
+        "date": "Oct 2016 – Feb 2017"
       },
       {
-        "title": "Sales Representative",
+        "role": "Sales Representative",
         "company": "Frankel",
-        "dates": "Jun 2016 – Sep 2016",
-        "tasks": [
-          "Prospected B2B clients and prepared quotations",
-          "Negotiated deals and collaborated with team"
-        ]
+        "description": [
+          "B2B prospecting, quotations, and negotiation",
+          "Team collaboration and sales reporting"
+        ],
+        "date": "Jun 2016 – Sep 2016"
       },
       {
-        "title": "Electrical Maintenance Intern",
+        "role": "Sales Intern",
+        "company": "Frankel",
+        "description": [
+          "Prospecting and quotation preparation",
+          "Sales support"
+        ],
+        "date": "2014 – 2016"
+      },
+      {
+        "role": "Intern — Electrical Maintenance Technician",
         "company": "Eiffage",
-        "dates": "Oct 2013 – Dec 2013",
-        "tasks": [
-          "Assisted with electrical maintenance and diagnostics",
-          "Followed safety standards and supported team"
-        ]
+        "description": [
+          "Reading schematics and fault diagnostics",
+          "Preventive and corrective maintenance"
+        ],
+        "date": "Oct 2013 – Dec 2013"
       },
       {
-        "title": "Electrical Maintenance Intern",
+        "role": "Intern — Electrical Maintenance Technician",
         "company": "EDF",
-        "dates": "Oct 2012 – Dec 2012",
-        "tasks": [
-          "Performed electrical diagnostics and maintenance",
-          "Ensured compliance with safety standards"
-        ]
+        "description": [
+          "Low-voltage interventions, measuring & control tools",
+          "Electrical safety and team collaboration"
+        ],
+        "date": "Oct 2012 – Dec 2012"
+      }
+    ]
+  },
+
+  "education": {
+    "title": "Education",
+    "items": [
+      {
+        "school": "Duke Language School",
+        "degree": "English Language Student",
+        "date": "May 2025 – Sep 2025"
       },
       {
-        "title": "Multi-skilled Agent / Delivery Driver",
-        "company": "Various municipalities & companies",
-        "dates": "Various periods",
-        "tasks": [
-          "Delivered parcels and logistics support",
-          "Offered technical assistance to municipalities"
-        ]
+        "school": "Patong Language School",
+        "degree": "English Language Student",
+        "date": "Jun 2024 – Sep 2024"
+      },
+      {
+        "school": "Le Wagon — Paris",
+        "degree": "Web Application Developer (Bootcamp)",
+        "date": "Jan 2023 – Jul 2023"
+      },
+      {
+        "school": "Lycée Parc de Vilgénis — Massy",
+        "degree": "Higher National Diploma of Business and Sales Technician (BTS)",
+        "date": "2014 – 2016"
+      },
+      {
+        "school": "Lycée Léonard de Vinci — Saint-Michel-sur-Orge",
+        "degree": "High school diploma — Electrical/Electronic Maintenance & Repair",
+        "date": "2011 – 2014"
       }
     ]
   },

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -64,94 +64,128 @@
     "subtitle": "Parcours professionnel",
     "items": [
       {
-        "title": "Technicien maintenance recyclage",
+        "role": "Technicien de maintenance en recyclage",
         "company": "Rino Recycling",
-        "dates": "Oct 2024 – Avr 2025",
-        "tasks": [
-          "Exploitation et maintenance des équipements",
-          "Sécurité et soutien logistique"
-        ]
+        "description": [
+          "Exploitation et surveillance des équipements de recyclage",
+          "Maintenance préventive et dépannage",
+          "Tri selon les standards qualité et respect des règles HSE",
+          "Soutien logistique et coordination d’équipe"
+        ],
+        "date": "Oct 2024 – Avr 2025"
       },
       {
-        "title": "Assistant bibliothécaire & coordinateur livraisons",
+        "role": "Assistant bibliothécaire & Chauffeur-livreur",
         "company": "Cœur d’Essonne Agglomération",
-        "dates": "Sep 2019 – Avr 2024",
-        "tasks": [
-          "Gestion des prêts et livraisons",
-          "Supervision des chauffeurs et catalogage"
-        ]
+        "description": [
+          "Classement, prêts/retours et assistance aux usagers",
+          "Coordination des tournées et supervision des livreurs",
+          "Livraisons, suivi des véhicules et tenue des registres"
+        ],
+        "date": "Sept 2019 – Avr 2024"
       },
       {
-        "title": "Plongeur / serveur",
-        "company": "Sofitel",
-        "dates": "Avr 2019 – Aoû 2019",
-        "tasks": [
-          "Aide en cuisine et propreté",
-          "Service en salle et prise de commandes"
-        ]
+        "role": "Plongeur, Aide de cuisine & Serveur",
+        "company": "Sofitel (Accor Hotels)",
+        "description": [
+          "Préparation, dressage et service en salle",
+          "Nettoyage et organisation de la cuisine"
+        ],
+        "date": "Avr 2019 – Août 2019"
       },
       {
-        "title": "Technicien de maintenance",
+        "role": "Technicien de maintenance",
         "company": "Aximum",
-        "dates": "Mar 2018 – Mar 2019",
-        "tasks": [
-          "Entretien et réparation des feux de signalisation",
-          "Diagnostic des pannes et respect des normes"
-        ]
+        "description": [
+          "Maintenance préventive/curative des signalisations tricolores",
+          "Dépannage, tests et conformité sécurité/réglementaire"
+        ],
+        "date": "Mar 2018 – Mar 2019"
       },
       {
-        "title": "Technicien environnement",
+        "role": "Technicien environnement",
         "company": "Cœur d’Essonne Agglomération",
-        "dates": "Mar 2017 – Fév 2018",
-        "tasks": [
-          "Inspection des réseaux et application des règlements",
-          "Collecte de données et résolution des problèmes environnementaux"
-        ]
+        "description": [
+          "Contrôle des réseaux d’assainissement et prélèvements",
+          "Rapports d’analyses et conformité réglementaire"
+        ],
+        "date": "Mar 2017 – Fév 2018"
       },
       {
-        "title": "Agent de vente",
+        "role": "Agent de vente en gare",
         "company": "SNCF Réseau",
-        "dates": "Oct 2016 – Fév 2017",
-        "tasks": [
-          "Assistance aux voyageurs et vente de billets",
-          "Gestion des incidents via les systèmes SNCF"
-        ]
+        "description": [
+          "Vente de billets et assistance voyageurs",
+          "Gestion des incidents et communication"
+        ],
+        "date": "Oct 2016 – Fév 2017"
       },
       {
-        "title": "Commercial sédentaire",
+        "role": "Représentant commercial",
         "company": "Frankel",
-        "dates": "Jun 2016 – Sep 2016",
-        "tasks": [
-          "Prospection B2B et préparation de devis",
-          "Négociation et travail en équipe"
-        ]
+        "description": [
+          "Prospection B2B, devis et négociation",
+          "Collaboration équipe commerciale & reporting"
+        ],
+        "date": "Juin 2016 – Sept 2016"
       },
       {
-        "title": "Stagiaire maintenance électrique",
+        "role": "Stagiaire commercial",
+        "company": "Frankel",
+        "description": [
+          "Prospection, préparation de devis",
+          "Support aux ventes"
+        ],
+        "date": "2014 – 2016"
+      },
+      {
+        "role": "Stagiaire — Technicien de maintenance électrique",
         "company": "Eiffage",
-        "dates": "Oct 2013 – Déc 2013",
-        "tasks": [
-          "Maintenance et diagnostics électriques",
-          "Respect des normes de sécurité et support"
-        ]
+        "description": [
+          "Lecture de schémas, diagnostic des pannes",
+          "Maintenance préventive et corrective"
+        ],
+        "date": "Oct 2013 – Déc 2013"
       },
       {
-        "title": "Stagiaire maintenance électrique",
+        "role": "Stagiaire — Technicien de maintenance électrique",
         "company": "EDF",
-        "dates": "Oct 2012 – Déc 2012",
-        "tasks": [
-          "Diagnostics et maintenance électriques",
-          "Conformité aux normes de sécurité"
-        ]
+        "description": [
+          "Interventions sur systèmes basse tension",
+          "Mesures, contrôles et sécurité électrique"
+        ],
+        "date": "Oct 2012 – Déc 2012"
+      }
+    ]
+  },
+
+  "education": {
+    "title": "Éducation",
+    "items": [
+      {
+        "school": "Duke Language School",
+        "degree": "Étudiant en langue anglaise",
+        "date": "Mai 2025 – Sep 2025"
       },
       {
-        "title": "Agent polyvalent / livreur",
-        "company": "Diverses municipalités et entreprises",
-        "dates": "Périodes diverses",
-        "tasks": [
-          "Livraison de colis et soutien logistique",
-          "Assistance technique aux municipalités"
-        ]
+        "school": "Patong Language School",
+        "degree": "Étudiant en langue anglaise",
+        "date": "Juin 2024 – Sep 2024"
+      },
+      {
+        "school": "Le Wagon — Paris",
+        "degree": "Développeur d’applications web (Bootcamp)",
+        "date": "Jan 2023 – Juil 2023"
+      },
+      {
+        "school": "Lycée Parc de Vilgénis — Massy",
+        "degree": "BTS (Technicien supérieur en commerce et vente)",
+        "date": "2014 – 2016"
+      },
+      {
+        "school": "Lycée Léonard de Vinci — Saint-Michel-sur-Orge",
+        "degree": "Baccalauréat pro — Maintenance/Électronique",
+        "date": "2011 – 2014"
       }
     ]
   },


### PR DESCRIPTION
## Summary
- localize extended work history in French and English
- add education timeline entries in both locales

## Testing
- `npm run dev` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a00d809a048331a805966a4f4d7a18