### PR TITLE
chore: add missing Node types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.9.1",
+        "@types/node": "^20.0.0",
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
         "@types/react-vertical-timeline-component": "^3.3.6",
@@ -2926,6 +2927,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.11.tgz",
+      "integrity": "sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/offscreencanvas": {
       "version": "2019.7.3",
@@ -10024,7 +10035,7 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -10097,6 +10108,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",
+    "@types/node": "^20.0.0",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "@types/react-vertical-timeline-component": "^3.3.6",

--- a/scripts/debug-all.ts
+++ b/scripts/debug-all.ts
@@ -13,10 +13,11 @@ console.log('🛠️  Patching three-stdlib exports...');
 const pkgPath = join('node_modules', 'three-stdlib', 'package.json');
 if (fs.existsSync(pkgPath)) {
   const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as Record<string, unknown>;
+  const pkgExports = (pkg.exports ?? {}) as Record<string, unknown>;
   pkg.exports = {
     './package.json': './package.json',
     './*': './*',
-    ...pkg.exports,
+    ...pkgExports,
   };
   fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
   console.log('✅ three-stdlib exports patched.');

--- a/scripts/fix-three.ts
+++ b/scripts/fix-three.ts
@@ -69,8 +69,9 @@ async function patchStdlib() {
   const stdlibPkgPath = join('node_modules', 'three-stdlib', 'package.json');
   if (existsSync(stdlibPkgPath)) {
     const pkg = JSON.parse(fs.readFileSync(stdlibPkgPath, 'utf8')) as Record<string, unknown>;
+    const pkgExports = (pkg.exports ?? {}) as Record<string, unknown>;
     pkg.exports = {
-      ...(pkg.exports || {}),
+      ...pkgExports,
       './nodes': '../three/examples/jsm/nodes/Nodes.js',
       './shaders/AdditiveBlendingShader': '../three/examples/jsm/shaders/AdditiveBlendingShader.js',
       './renderers/webgpu/WebGPURenderer': '../three/examples/jsm/renderers/webgpu/WebGPURenderer.js',


### PR DESCRIPTION
## Summary
- add `@types/node` dev dependency for production builds
- guard script patches against missing exports

## Testing
- `npm run typecheck`
- `npm run build` *(fails: Property 'map' does not exist on type '$SpecialObject')*

------
https://chatgpt.com/codex/tasks/task_b_68a1c51423048331998b7b41c1567b18